### PR TITLE
Upgrade to .Net Standard 2.1

### DIFF
--- a/Kinde.Api.Test/Kinde.Api.Test.csproj
+++ b/Kinde.Api.Test/Kinde.Api.Test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Kinde.Api.Test</AssemblyName>
     <RootNamespace>Kinde.Api.Test</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>annotations</Nullable>
   </PropertyGroup>

--- a/Kinde.Api/IsExternalInit.cs
+++ b/Kinde.Api/IsExternalInit.cs
@@ -1,0 +1,7 @@
+namespace System.Runtime.CompilerServices
+{
+    using System.ComponentModel;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit {}
+}

--- a/Kinde.Api/Kinde.Api.csproj
+++ b/Kinde.Api/Kinde.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Kinde.SDK</PackageId>
     <OutputType>Library</OutputType>
     <Authors>Kinde</Authors>
@@ -25,6 +25,7 @@
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -41,11 +42,11 @@
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.5.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.8.0" />
   </ItemGroup>
 
 </Project>

--- a/Kinde.Api/KindeHttpClient.cs
+++ b/Kinde.Api/KindeHttpClient.cs
@@ -31,14 +31,5 @@ namespace Kinde.Api
 
             return base.SendAsync(request, cancellationToken);
         }
-
-        public override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            request.Headers.TryAddWithoutValidation("cache-control", "no-cache");
-            request.Headers.TryAddWithoutValidation("User-Agent", "PostmanRuntime/7.29.2");
-            if (Token != null) request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + Token.AccessToken);
-
-            return base.Send(request, cancellationToken);
-        }
     }
 }


### PR DESCRIPTION
.Net 6 is no longer supported by Microsoft, also, a .Net 6 project cannot be imported into a .NetStandard Class Library. This PR upgrades the library to use .NetStandard rather than .Net 8 and updates it's dependencies accordingly.  

This will provide additional flexibility for usage 

# Changes

Updates the target framework for test project to .NET 8.0.

Updates the target framework for the main project to netstandard2.1 and sets LangVersion to 10.

Updates package references for Polly and Microsoft.Extensions.Configuration to the latest versions and System.IdentityModel.Tokens.Jwt.

Adds IsExternalInit.cs to support record types in older target frameworks.
