### PR TITLE
ci: add automated build, test, and release workflows

### DIFF
--- a/.github/RELEASE_PROCESS.md
+++ b/.github/RELEASE_PROCESS.md
@@ -1,0 +1,183 @@
+# Release Process for Kinde .NET SDK
+
+This document describes the automated release process for the Kinde .NET SDK using GitHub Actions.
+
+## Overview
+
+The release process is fully automated using GitHub Actions workflows. When you create a version tag, the system will:
+
+1. Build and test the project
+2. Create a NuGet package
+3. Create a GitHub release
+4. Publish the package to NuGet.org
+
+## Workflows
+
+### 1. Build and Test (`build-and-test.yml`)
+- **Trigger**: Push to `main`/`develop` branches or pull requests
+- **Purpose**: Ensures code quality by building and testing across multiple .NET versions
+- **Runs on**: Ubuntu with .NET 6.0, 7.0, and 8.0
+
+### 2. Version Bump (`version-bump.yml`)
+- **Trigger**: Push to `main` branch (excluding markdown files)
+- **Purpose**: Automatically increments the patch version when code changes
+- **Note**: Add `[skip ci]` to commit messages to skip this workflow
+
+### 3. Create Release (`create-release.yml`)
+- **Trigger**: Manual workflow dispatch
+- **Purpose**: Creates GitHub releases with NuGet packages attached
+- **Access**: Restricted to authorized users
+
+### 4. Publish to NuGet (`publish-nuget.yml`)
+- **Trigger**: Manual workflow dispatch
+- **Purpose**: Publishes packages to NuGet.org
+- **Access**: Restricted to authorized users
+
+### 5. Manual Release and Publish (`manual-release.yml`)
+- **Trigger**: Manual workflow dispatch
+- **Purpose**: Combined workflow for creating releases and publishing to NuGet
+- **Access**: Restricted to authorized users
+
+## Creating a Release
+
+### Option 1: Using GitHub Actions (Recommended)
+
+1. Go to the GitHub repository
+2. Navigate to the "Actions" tab
+3. Select "Manual Release and Publish" workflow
+4. Click "Run workflow"
+5. Fill in the required information:
+   - **Version**: The version to release (e.g., 1.3.2)
+   - **Release notes**: Optional release notes
+   - **Publish to NuGet.org**: Check this to publish to NuGet
+6. Click "Run workflow"
+
+This workflow will:
+- Build and test the project
+- Update the version in `Kinde.Api.csproj`
+- Create a NuGet package
+- Create a git tag and push it
+- Create a GitHub release
+- Optionally publish to NuGet.org
+
+### Option 2: Using the Release Script
+
+1. Navigate to the project root:
+   ```bash
+   cd kinde-dotnet-sdk
+   ```
+
+2. Run the release script:
+   ```bash
+   ./scripts/create-release.sh 1.3.2
+   ```
+
+   This script will:
+   - Update the version in `Kinde.Api.csproj`
+   - Build and test the project
+   - Create a NuGet package
+   - Commit the version change
+   - Create and push a git tag
+
+### Option 3: Manual Process
+
+1. Update the version in `Kinde.Api/Kinde.Api.csproj`:
+   ```xml
+   <Version>1.3.2</Version>
+   ```
+
+2. Build and test:
+   ```bash
+   dotnet build --configuration Release
+   dotnet test --configuration Release
+   ```
+
+3. Create and push a tag:
+   ```bash
+   git add Kinde.Api/Kinde.Api.csproj
+   git commit -m "Bump version to 1.3.2"
+   git tag -a v1.3.2 -m "Release version 1.3.2"
+   git push origin main
+   git push origin v1.3.2
+   ```
+
+## Required Secrets
+
+To enable NuGet publishing, add the following secrets to your GitHub repository:
+
+1. Go to your repository settings
+2. Navigate to "Secrets and variables" → "Actions"
+3. Add the following secret:
+   - `NUGET_API_KEY`: Your NuGet API key for publishing packages
+
+## User Access Control
+
+The manual release workflows are restricted to authorized users. To modify the access restrictions:
+
+1. Edit the workflow files in `.github/workflows/`
+2. Update the `if` condition in the job section
+3. Add or remove usernames/organizations as needed
+
+Example:
+```yaml
+if: |
+  github.actor == 'kinde-oss' ||
+  github.actor == 'your-username' ||
+  contains(github.actor, 'kinde')
+```
+
+**Note**: Replace `'your-username'` with actual GitHub usernames who should have access to run these workflows.
+
+### Getting a NuGet API Key
+
+1. Go to [NuGet.org](https://www.nuget.org)
+2. Sign in to your account
+3. Go to "API Keys" in your account settings
+4. Create a new API key with "Push" permissions
+5. Copy the key and add it to your GitHub secrets
+
+## Versioning Strategy
+
+The project follows semantic versioning (SemVer):
+
+- **Major version** (1.x.x): Breaking changes
+- **Minor version** (x.2.x): New features, backward compatible
+- **Patch version** (x.x.3): Bug fixes, backward compatible
+
+The automated version bump workflow increments the patch version automatically. For major or minor version changes, manually update the version in the csproj file.
+
+## Troubleshooting
+
+### Workflow Failures
+
+1. Check the GitHub Actions tab for detailed error messages
+2. Ensure all required secrets are configured
+3. Verify the NuGet API key has the correct permissions
+
+### Package Publishing Issues
+
+1. Check if the package already exists on NuGet.org
+2. Verify the version number is unique
+3. Ensure the package meets NuGet.org requirements
+
+### Skipping Automated Version Bump
+
+Add `[skip ci]` to your commit message to skip the automated version bump:
+
+```bash
+git commit -m "Update documentation [skip ci]"
+```
+
+## Monitoring
+
+- **GitHub Actions**: Monitor workflow runs in the Actions tab
+- **NuGet.org**: Check package status at https://www.nuget.org/packages/Kinde.SDK
+- **GitHub Releases**: View releases at https://github.com/kinde-oss/kinde-dotnet-sdk/releases
+
+## Support
+
+If you encounter issues with the release process:
+
+1. Check the GitHub Actions logs for detailed error messages
+2. Verify all secrets are properly configured
+3. Ensure you have the necessary permissions for the repository

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,43 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        dotnet-version: ['6.0.x', '7.0.x', '8.0.x']
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ matrix.dotnet-version }}
+    
+    - name: Restore dependencies
+      run: dotnet restore
+    
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+    
+    - name: Test
+      run: dotnet test --no-build --verbosity normal --configuration Release
+    
+    - name: Run tests with coverage
+      run: dotnet test --no-build --verbosity normal --configuration Release --collect:"XPlat Code Coverage" --results-directory ./coverage
+    
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage/**/coverage.cobertura.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,55 @@
+name: Code Quality
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  code-quality:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+    
+    - name: Restore dependencies
+      run: dotnet restore
+    
+    - name: Run code analysis
+      run: dotnet build --configuration Release --verbosity normal
+    
+    - name: Run security analysis
+      run: dotnet list package --vulnerable
+    
+    - name: Check for outdated packages
+      run: dotnet list package --outdated
+    
+    - name: Validate project structure
+      run: |
+        # Check if csproj files exist
+        if [ ! -f "Kinde.Api/Kinde.Api.csproj" ]; then
+          echo "Error: Kinde.Api.csproj not found"
+          exit 1
+        fi
+        
+        if [ ! -f "Kinde.Api.Test/Kinde.Api.Test.csproj" ]; then
+          echo "Error: Kinde.Api.Test.csproj not found"
+          exit 1
+        fi
+        
+        echo "Project structure validation passed"
+    
+    - name: Validate package metadata
+      run: |
+        # Check if required package properties are set
+        grep -q "<PackageId>" Kinde.Api/Kinde.Api.csproj || (echo "Error: PackageId not found" && exit 1)
+        grep -q "<Version>" Kinde.Api/Kinde.Api.csproj || (echo "Error: Version not found" && exit 1)
+        grep -q "<Authors>" Kinde.Api/Kinde.Api.csproj || (echo "Error: Authors not found" && exit 1)
+        grep -q "<Description>" Kinde.Api/Kinde.Api.csproj || (echo "Error: Description not found" && exit 1)
+        echo "Package metadata validation passed"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,94 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.3.2)'
+        required: true
+        type: string
+      release_notes:
+        description: 'Release notes (optional)'
+        required: false
+        type: string
+        default: 'This release includes the latest updates to the Kinde .NET SDK.'
+
+jobs:
+  build-and-package:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+    
+    - name: Restore dependencies
+      run: dotnet restore
+    
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+    
+    - name: Test
+      run: dotnet test --no-build --verbosity normal --configuration Release
+    
+    - name: Pack
+      run: dotnet pack Kinde.Api/Kinde.Api.csproj --configuration Release --output ./nupkgs --no-build
+    
+    - name: Upload NuGet packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-packages
+        path: ./nupkgs/
+        retention-days: 30
+    
+    - name: Update version in csproj
+      run: |
+        sed -i "s/<Version>.*<\/Version>/<Version>${{ github.event.inputs.version }}<\/Version>/" Kinde.Api/Kinde.Api.csproj
+    
+    - name: Create git tag
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add Kinde.Api/Kinde.Api.csproj
+        git commit -m "Bump version to ${{ github.event.inputs.version }}"
+        git tag -a "v${{ github.event.inputs.version }}" -m "Release version ${{ github.event.inputs.version }}"
+        git push origin main
+        git push origin "v${{ github.event.inputs.version }}"
+    
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ github.event.inputs.version }}
+        release_name: Release ${{ github.event.inputs.version }}
+        draft: false
+        prerelease: false
+        body: |
+          ## What's Changed
+          
+          ${{ github.event.inputs.release_notes }}
+          
+          ### 📦 NuGet Package
+          The NuGet package is available at: `Kinde.SDK`
+          
+          ### 🔗 Links
+          - [NuGet Package](https://www.nuget.org/packages/Kinde.SDK)
+          - [Documentation](https://github.com/kinde-oss/kinde-dotnet-sdk)
+          
+          ### 📋 Changelog
+          Please refer to the commit history for detailed changes.
+    
+    - name: Upload Release Assets
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./nupkgs/Kinde.SDK.${{ github.event.inputs.version }}.nupkg
+        asset_name: Kinde.SDK.${{ github.event.inputs.version }}.nupkg
+        asset_content_type: application/octet-stream

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -1,0 +1,61 @@
+name: Dependency Update
+
+on:
+  schedule:
+    # Run every Monday at 9 AM UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+    
+    - name: Check for outdated packages
+      id: check-outdated
+      run: |
+        OUTDATED=$(dotnet list package --outdated --format json | jq -r '.projects[].frameworks[].topLevelPackages[] | select(.resolvedVersion != .latestVersion) | "\(.id):\(.resolvedVersion)->\(.latestVersion)"')
+        if [ -n "$OUTDATED" ]; then
+          echo "outdated_packages=true" >> $GITHUB_OUTPUT
+          echo "packages=$OUTDATED" >> $GITHUB_OUTPUT
+          echo "Found outdated packages:"
+          echo "$OUTDATED"
+        else
+          echo "outdated_packages=false" >> $GITHUB_OUTPUT
+          echo "No outdated packages found"
+        fi
+    
+    - name: Create Pull Request for Updates
+      if: steps.check-outdated.outputs.outdated_packages == 'true'
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "chore: update dependencies"
+        title: "chore: update dependencies"
+        body: |
+          ## Dependency Updates
+          
+          This PR updates the following packages:
+          
+          ${{ steps.check-outdated.outputs.packages }}
+          
+          ### Changes
+          - Automated dependency updates
+          - All packages updated to their latest versions
+          
+          ### Testing
+          - [ ] Build passes
+          - [ ] Tests pass
+          - [ ] No breaking changes
+        branch: dependency-updates
+        delete-branch: true
+        labels: |
+          dependencies
+          automated

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,109 @@
+name: Manual Release and Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.3.2)'
+        required: true
+        type: string
+      release_notes:
+        description: 'Release notes (optional)'
+        required: false
+        type: string
+        default: 'This release includes the latest updates to the Kinde .NET SDK.'
+      publish_to_nuget:
+        description: 'Publish to NuGet.org'
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Restrict to specific users/organizations
+    if: |
+      github.actor == 'kinde-oss' ||
+      github.actor == 'your-username' ||
+      contains(github.actor, 'kinde')
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+    
+    - name: Restore dependencies
+      run: dotnet restore
+    
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+    
+    - name: Test
+      run: dotnet test --no-build --verbosity normal --configuration Release
+    
+    - name: Update version in csproj
+      run: |
+        sed -i "s/<Version>.*<\/Version>/<Version>${{ github.event.inputs.version }}<\/Version>/" Kinde.Api/Kinde.Api.csproj
+    
+    - name: Pack
+      run: dotnet pack Kinde.Api/Kinde.Api.csproj --configuration Release --output ./nupkgs --no-build
+    
+    - name: Create git tag
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add Kinde.Api/Kinde.Api.csproj
+        git commit -m "Bump version to ${{ github.event.inputs.version }}"
+        git tag -a "v${{ github.event.inputs.version }}" -m "Release version ${{ github.event.inputs.version }}"
+        git push origin main
+        git push origin "v${{ github.event.inputs.version }}"
+    
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ github.event.inputs.version }}
+        release_name: Release ${{ github.event.inputs.version }}
+        draft: false
+        prerelease: false
+        body: |
+          ## What's Changed
+          
+          ${{ github.event.inputs.release_notes }}
+          
+          ### 📦 NuGet Package
+          The NuGet package is available at: `Kinde.SDK`
+          
+          ### 🔗 Links
+          - [NuGet Package](https://www.nuget.org/packages/Kinde.SDK)
+          - [Documentation](https://github.com/kinde-oss/kinde-dotnet-sdk)
+          
+          ### 📋 Changelog
+          Please refer to the commit history for detailed changes.
+    
+    - name: Upload Release Assets
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./nupkgs/Kinde.SDK.${{ github.event.inputs.version }}.nupkg
+        asset_name: Kinde.SDK.${{ github.event.inputs.version }}.nupkg
+        asset_content_type: application/octet-stream
+    
+    - name: Publish to NuGet
+      if: ${{ github.event.inputs.publish_to_nuget == 'true' }}
+      run: dotnet nuget push ./nupkgs/Kinde.SDK.${{ github.event.inputs.version }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+    
+    - name: Publish Symbol Package
+      if: ${{ github.event.inputs.publish_to_nuget == 'true' }}
+      run: dotnet nuget push ./nupkgs/Kinde.SDK.${{ github.event.inputs.version }}.snupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      continue-on-error: true

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,40 @@
+name: Publish to NuGet
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.3.2)'
+        required: true
+        type: string
+      confirm_publish:
+        description: 'Confirm you want to publish to NuGet.org'
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.confirm_publish == 'true' }}
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+    
+    - name: Build and pack
+      run: |
+        dotnet restore
+        dotnet build --configuration Release
+        dotnet pack Kinde.Api/Kinde.Api.csproj --configuration Release --output ./nupkgs --no-build
+    
+    - name: Publish to NuGet
+      run: dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+    
+    - name: Publish Symbol Package
+      run: dotnet nuget push ./nupkgs/*.snupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      continue-on-error: true

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,55 @@
+name: Version Bump
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/version-bump.yml'
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+    
+    - name: Get current version
+      id: current_version
+      run: |
+        VERSION=$(grep -o '<Version>.*</Version>' Kinde.Api/Kinde.Api.csproj | sed 's/<Version>\(.*\)<\/Version>/\1/')
+        echo "current_version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Current version: $VERSION"
+    
+    - name: Calculate new version
+      id: new_version
+      run: |
+        CURRENT_VERSION=${{ steps.current_version.outputs.current_version }}
+        MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
+        MINOR=$(echo $CURRENT_VERSION | cut -d. -f2)
+        PATCH=$(echo $CURRENT_VERSION | cut -d. -f3)
+        NEW_PATCH=$((PATCH + 1))
+        NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+        echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+        echo "New version: $NEW_VERSION"
+    
+    - name: Update version in csproj
+      run: |
+        sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.new_version.outputs.new_version }}<\/Version>/" Kinde.Api/Kinde.Api.csproj
+    
+    - name: Commit and push version bump
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add Kinde.Api/Kinde.Api.csproj
+        git commit -m "Bump version to ${{ steps.new_version.outputs.new_version }} [skip ci]"
+        git push

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Create Release Script for Kinde .NET SDK
+# This script helps create a new release by creating a git tag
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if we're in a git repository
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    print_error "Not in a git repository"
+    exit 1
+fi
+
+# Get current version from csproj file
+CURRENT_VERSION=$(grep -o '<Version>.*</Version>' Kinde.Api/Kinde.Api.csproj | sed 's/<Version>\(.*\)<\/Version>/\1/')
+
+print_status "Current version: $CURRENT_VERSION"
+
+# Check if version parameter is provided
+if [ $# -eq 0 ]; then
+    print_error "Please provide a version number (e.g., 1.3.2)"
+    echo "Usage: $0 <version>"
+    echo "Example: $0 1.3.2"
+    exit 1
+fi
+
+NEW_VERSION=$1
+
+# Validate version format (simple check)
+if ! [[ $NEW_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    print_error "Invalid version format. Please use semantic versioning (e.g., 1.3.2)"
+    exit 1
+fi
+
+print_status "Creating release for version: $NEW_VERSION"
+
+# Check if tag already exists
+if git tag -l | grep -q "v$NEW_VERSION"; then
+    print_error "Tag v$NEW_VERSION already exists"
+    exit 1
+fi
+
+# Update version in csproj file
+print_status "Updating version in Kinde.Api.csproj..."
+sed -i.bak "s/<Version>.*<\/Version>/<Version>$NEW_VERSION<\/Version>/" Kinde.Api/Kinde.Api.csproj
+rm Kinde.Api/Kinde.Api.csproj.bak
+
+# Build and test the project
+print_status "Building project..."
+dotnet build --configuration Release
+
+print_status "Running tests..."
+dotnet test --configuration Release
+
+# Create NuGet package
+print_status "Creating NuGet package..."
+dotnet pack Kinde.Api/Kinde.Api.csproj --configuration Release --output ./nupkgs --no-build
+
+# Commit version change
+print_status "Committing version change..."
+git add Kinde.Api/Kinde.Api.csproj
+git commit -m "Bump version to $NEW_VERSION"
+
+# Create and push tag
+print_status "Creating tag v$NEW_VERSION..."
+git tag -a "v$NEW_VERSION" -m "Release version $NEW_VERSION"
+
+print_status "Pushing changes and tag..."
+git push origin main
+git push origin "v$NEW_VERSION"
+
+print_status "Release created successfully!"
+print_status "Tag: v$NEW_VERSION"
+print_status "NuGet package created in: ./nupkgs/"
+print_status "GitHub Actions will now create a release and publish to NuGet.org"
+
+# Show next steps
+echo ""
+print_warning "Next steps:"
+echo "1. Wait for GitHub Actions to complete the release process"
+echo "2. Verify the release on GitHub: https://github.com/kinde-oss/kinde-dotnet-sdk/releases"
+echo "3. Verify the package on NuGet: https://www.nuget.org/packages/Kinde.SDK"


### PR DESCRIPTION
# Explain your changes

- Add GitHub Actions workflows for build and test across .NET 6/7/8
- Add code quality workflow with security and dependency checks
- Add automated version bump workflow for patch releases
- Add manual release workflows for creating releases and publishing to NuGet
- Add dependency update workflow for automated dependency PRs
- Add comprehensive release process documentation
- Add automated release script for local use

This establishes a complete CI/CD pipeline for automated building, testing, quality checks, versioning, and NuGet package publishing.

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
