### PR TITLE
Validate auth redirect and use ApiException

### DIFF
--- a/Kinde.Api/Flows/BaseAuthorizationFlow.cs
+++ b/Kinde.Api/Flows/BaseAuthorizationFlow.cs
@@ -228,10 +228,7 @@ namespace Kinde.Api.Flows
             var content = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode || string.IsNullOrEmpty(content))
             {
-                throw new Kinde.Accounts.Client.ApiException(
-                                         response.ReasonPhrase,
-                                         response.StatusCode,
-                                         content);
+                throw new Kinde.Accounts.Client.ApiException(response.ReasonPhrase, response.StatusCode, content);
             }
             Token = JsonConvert.DeserializeObject<OauthToken>(content);
             return Token;

--- a/Kinde.Api/Flows/BaseAuthorizationFlow.cs
+++ b/Kinde.Api/Flows/BaseAuthorizationFlow.cs
@@ -55,12 +55,12 @@ namespace Kinde.Api.Flows
             if (register)
             {
                 parameters.Add("start_page", "registration");
-                
+
                 if (!string.IsNullOrEmpty(Configuration.PlanInterest))
                 {
                     parameters.Add("plan_interest", Configuration.PlanInterest);
                 }
-                
+
                 if (!string.IsNullOrEmpty(Configuration.PricingTableKey))
                 {
                     parameters.Add("pricing_table_key", Configuration.PricingTableKey);
@@ -79,13 +79,13 @@ namespace Kinde.Api.Flows
             if (RequiresRedirection)
             {
                 var url = BuildUrl(IdentityProviderConfiguration.Domain + "/oauth2/auth", parameters);
-                
+
                 // Make HTTP request to validate the authorization URL
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
                 var response = await httpClient.SendAsync(request);
-                
+
                 // Check if the response is a redirect (which is expected for authorization flows)
-                if (response.StatusCode == System.Net.HttpStatusCode.Redirect || 
+                if (response.StatusCode == System.Net.HttpStatusCode.Redirect ||
                     response.StatusCode == System.Net.HttpStatusCode.Found)
                 {
                     // Valid redirect response - proceed with setting up for user action
@@ -228,9 +228,11 @@ namespace Kinde.Api.Flows
             var content = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode || string.IsNullOrEmpty(content))
             {
-                throw new ApplicationException("Invalid response from server: No token received");
+                throw new Kinde.Accounts.Client.ApiException(
+                                         response.ReasonPhrase,
+                                         response.StatusCode,
+                                         content);
             }
-
             Token = JsonConvert.DeserializeObject<OauthToken>(content);
             return Token;
         }


### PR DESCRIPTION
Make an HTTP GET to the built authorization URL and verify the response is a redirect (Redirect or Found) before proceeding, ensuring the authorization endpoint is reachable and behaves as expected. Replace a generic ApplicationException when no token is returned with Kinde.Accounts.Client.ApiException that includes the response reason, status code, and content to provide richer error details. Also perform minor whitespace cleanup.

Fixes #22

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).