### PR TITLE
Throw ApiException on invalid token response

### DIFF
--- a/Kinde.Api.Test/AuthorizationTests.cs
+++ b/Kinde.Api.Test/AuthorizationTests.cs
@@ -5,9 +5,8 @@ using Kinde.Api.Models.Tokens;
 using Kinde.Api.Model;
 using Kinde.Api.Test.Mocks;
 using Kinde.Api.Test.Mocks.Flows;
+using Kinde.Api.Flows;
 using Newtonsoft.Json;
-using System.Diagnostics;
-using System.Reflection;
 using Xunit;
 
 namespace Kinde.Api.Test
@@ -40,7 +39,7 @@ namespace Kinde.Api.Test
             //Act
             if (throws)
             {
-                await Assert.ThrowsAsync<ApplicationException>(async () => { await apiClient.Authorize(authConfig); });
+                await Assert.ThrowsAsync<KindeAuthenticationException>(async () => { await apiClient.Authorize(authConfig); });
                 return;
             }
             await apiClient.Authorize(authConfig);
@@ -71,7 +70,7 @@ namespace Kinde.Api.Test
             //Act
             if (throws)
             {
-                await Assert.ThrowsAsync<ApplicationException>(async () => { await apiClient.Authorize(authConfig); });
+                await Assert.ThrowsAsync<KindeAuthenticationException>(async () => { await apiClient.Authorize(authConfig); });
                 return;
             }
             await apiClient.Authorize(authConfig);
@@ -102,7 +101,7 @@ namespace Kinde.Api.Test
             //Act
             if (throws)
             {
-                await Assert.ThrowsAsync<ApplicationException>(async () => { await apiClient.Authorize(authConfig); });
+                await Assert.ThrowsAsync<KindeAuthenticationException>(async () => { await apiClient.Authorize(authConfig); });
                 return;
             }
             await apiClient.Authorize(authConfig);
@@ -148,7 +147,7 @@ namespace Kinde.Api.Test
             //Act
             await apiClient.Authorize(authConfig);
             await apiClient.Logout();
-            var exception = await Assert.ThrowsAsync<ApplicationException>(async () => { await apiClient.GetToken(); });
+            var exception = await Assert.ThrowsAsync<KindeAuthenticationException>(async () => { await apiClient.GetToken(); });
 
             //Assert
             Assert.Equal("Please authorize first", exception.Message);
@@ -232,10 +231,10 @@ namespace Kinde.Api.Test
             {
                 Content = new StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(portalResponse))
             };
-            
+
             // Ensure the response is properly set up
             response.EnsureSuccessStatusCode();
-            
+
             var handler = new MockHttpMessageHandler(response);
             var client = new HttpClient(handler);
             var apiClient = new KindeClient(new MockIdentityProviderConfiguration(), client);
@@ -243,7 +242,7 @@ namespace Kinde.Api.Test
             // Mock authentication by setting up AuthorizationFlow with a valid token
             var token = new OauthToken { AccessToken = "test_token", ExpiresIn = 3600 };
             var mockAuthFlow = new MockAuthorizationFlow(token);
-            
+
             // Set the AuthorizationFlow before any HTTP requests are made
             var authFlowProperty = apiClient.GetType().GetProperty("AuthorizationFlow", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             if (authFlowProperty == null)
@@ -265,7 +264,7 @@ namespace Kinde.Api.Test
             // Assert
             Assert.NotNull(result);
             Assert.Equal("https://test.kinde.com/portal/profile", result.Url);
-            
+
             // Verify the request was made correctly
             Assert.NotNull(handler.Request);
             Assert.Equal(HttpMethod.Get, handler.Request.Method);

--- a/Kinde.Api/Flows/BaseAuthorizationFlow.cs
+++ b/Kinde.Api/Flows/BaseAuthorizationFlow.cs
@@ -228,7 +228,7 @@ namespace Kinde.Api.Flows
             var content = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode || string.IsNullOrEmpty(content))
             {
-                throw new KindeAuthenticationException($"Invalid response from server. StatusCode: {response.StatusCode}", response.StatusCode, content);
+                throw new KindeAuthenticationException($"Invalid response from server. StatusCode: {response.StatusCode}", response.StatusCode, content, false);
             }
 
             Token = JsonConvert.DeserializeObject<OauthToken>(content);
@@ -238,7 +238,7 @@ namespace Kinde.Api.Flows
         {
             if (Token == null)
             {
-                throw new ApplicationException("Please authorize first");
+                throw new KindeAuthenticationException("Please authorize first");
             }
 
             if (!Token.IsExpired)

--- a/Kinde.Api/Flows/BaseAuthorizationFlow.cs
+++ b/Kinde.Api/Flows/BaseAuthorizationFlow.cs
@@ -228,12 +228,13 @@ namespace Kinde.Api.Flows
             var content = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode || string.IsNullOrEmpty(content))
             {
-                throw new KindeAuthenticationException($"Invalid response from server. StatusCode: {response.StatusCode}", response.StatusCode, content, false);
+                throw new KindeAuthenticationException($"Invalid response from server. StatusCode: {response.StatusCode}", response.StatusCode, content);
             }
 
             Token = JsonConvert.DeserializeObject<OauthToken>(content);
             return Token;
         }
+
         public async Task<string> GetOrRefreshToken(HttpClient httpClient)
         {
             if (Token == null)

--- a/Kinde.Api/Flows/BaseAuthorizationFlow.cs
+++ b/Kinde.Api/Flows/BaseAuthorizationFlow.cs
@@ -228,7 +228,7 @@ namespace Kinde.Api.Flows
             var content = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode || string.IsNullOrEmpty(content))
             {
-                throw new ApplicationException("Invalid response from server: No token received");
+                throw new Kinde.Accounts.Client.ApiException(response.ReasonPhrase, response.StatusCode, content);
             }
 
             Token = JsonConvert.DeserializeObject<OauthToken>(content);

--- a/Kinde.Api/Flows/BaseAuthorizationFlow.cs
+++ b/Kinde.Api/Flows/BaseAuthorizationFlow.cs
@@ -55,12 +55,12 @@ namespace Kinde.Api.Flows
             if (register)
             {
                 parameters.Add("start_page", "registration");
-                
+
                 if (!string.IsNullOrEmpty(Configuration.PlanInterest))
                 {
                     parameters.Add("plan_interest", Configuration.PlanInterest);
                 }
-                
+
                 if (!string.IsNullOrEmpty(Configuration.PricingTableKey))
                 {
                     parameters.Add("pricing_table_key", Configuration.PricingTableKey);
@@ -79,13 +79,13 @@ namespace Kinde.Api.Flows
             if (RequiresRedirection)
             {
                 var url = BuildUrl(IdentityProviderConfiguration.Domain + "/oauth2/auth", parameters);
-                
+
                 // Make HTTP request to validate the authorization URL
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
                 var response = await httpClient.SendAsync(request);
-                
+
                 // Check if the response is a redirect (which is expected for authorization flows)
-                if (response.StatusCode == System.Net.HttpStatusCode.Redirect || 
+                if (response.StatusCode == System.Net.HttpStatusCode.Redirect ||
                     response.StatusCode == System.Net.HttpStatusCode.Found)
                 {
                     // Valid redirect response - proceed with setting up for user action
@@ -228,13 +228,12 @@ namespace Kinde.Api.Flows
             var content = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode || string.IsNullOrEmpty(content))
             {
-                throw new Kinde.Accounts.Client.ApiException(response.ReasonPhrase, response.StatusCode, content);
+                throw new KindeAuthenticationException($"Invalid response from server. StatusCode: {response.StatusCode}", response.StatusCode, content);
             }
 
             Token = JsonConvert.DeserializeObject<OauthToken>(content);
             return Token;
         }
-
         public async Task<string> GetOrRefreshToken(HttpClient httpClient)
         {
             if (Token == null)

--- a/Kinde.Api/Flows/KindeAuthenticationException.cs
+++ b/Kinde.Api/Flows/KindeAuthenticationException.cs
@@ -9,11 +9,15 @@ namespace Kinde.Api.Flows
 
         public KindeAuthenticationException(string message) : base(message) { }
 
-        public KindeAuthenticationException(string message, HttpStatusCode statusCode, string? responseContent = null)
+        public KindeAuthenticationException(
+            string message,
+            HttpStatusCode statusCode,
+            string? responseContent = null,
+            bool includeResponseContent = false)
             : base(message)
         {
             StatusCode = statusCode;
-            ResponseContent = responseContent;
+            ResponseContent = includeResponseContent ? responseContent : null;
         }
 
         public KindeAuthenticationException(string message, Exception innerException)

--- a/Kinde.Api/Flows/KindeAuthenticationException.cs
+++ b/Kinde.Api/Flows/KindeAuthenticationException.cs
@@ -1,0 +1,22 @@
+﻿using System.Net;
+
+namespace Kinde.Api.Flows
+{
+    public class KindeAuthenticationException : Exception
+    {
+        public HttpStatusCode? StatusCode { get; }
+        public string? ResponseContent { get; }
+
+        public KindeAuthenticationException(string message) : base(message) { }
+
+        public KindeAuthenticationException(string message, HttpStatusCode statusCode, string? responseContent = null)
+            : base(message)
+        {
+            StatusCode = statusCode;
+            ResponseContent = responseContent;
+        }
+
+        public KindeAuthenticationException(string message, Exception innerException)
+            : base(message, innerException) { }
+    }
+}

--- a/Kinde.Api/KindeClient.cs
+++ b/Kinde.Api/KindeClient.cs
@@ -102,7 +102,7 @@ namespace Kinde.Api.Client
             var state = await AuthorizationFlow.Authorize(HttpClient, register);
             if (state == AuthorizationStates.NonAuthorized)
             {
-                throw new ApplicationException("Authorization failed");
+                throw new KindeAuthenticationException("Authorization failed");
             }
         }
 


### PR DESCRIPTION
Replace a generic ApplicationException with Kinde.Accounts.Client.ApiException in BaseAuthorizationFlow.cs, passing response.ReasonPhrase, response.StatusCode, and the response content. This provides richer error context and improves diagnostics when the token endpoint returns an error or empty content.

Fixes #22

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).