### PR TITLE
chore: release v2.1.0

### DIFF
--- a/Kinde.Api.Test/packages.lock.json
+++ b/Kinde.Api.Test/packages.lock.json
@@ -403,52 +403,62 @@
           "Microsoft.IdentityModel.Logging": "8.8.0"
         }
       },
+      "Microsoft.IO.RecyclableMemoryStream": {
+        "type": "Transitive",
+        "resolved": "3.0.1",
+        "contentHash": "s/s20YTVY9r9TPfTrN5g8zPF1YhwxyqO6PxUkrYTGI2B+OGPe9AdajWZrLhFqXIvqIW23fnUE4+ztrUWNU1+9g=="
+      },
       "Microsoft.Kiota.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.9.12",
-        "contentHash": "UtQAwW+PGJRw58zjQt3GNB4TuW3wXvSbyYrgmMXDjkMIo2q6N3GRbZ3nvZPsArYA0q1UdonxkuTB2kYOyC9JWQ==",
+        "resolved": "1.22.2",
+        "contentHash": "xktJuKVMXfcX9LJR0QH8gwbZ2WO+WrqTujCPtN13Y6GfLaB7wV0v1pv3hdO1Fek2/vKRpALhbdRYmFNoyzO1Sg==",
         "dependencies": {
-          "Std.UriTemplate": "1.0.5"
+          "Std.UriTemplate": "2.0.8"
         }
       },
       "Microsoft.Kiota.Http.HttpClientLibrary": {
         "type": "Transitive",
-        "resolved": "1.4.3",
-        "contentHash": "axLzUosoRzLoC67RDuzzjSyGaY9Daw7TrCKOmXRosbWSa/Vy7bm1m5OI+pmPcL95EyCq1S9Y2Pmdl/qJQL1SRA==",
+        "resolved": "1.22.2",
+        "contentHash": "t3rPJbiLKBuvFQoCK/wmgwSjRmvEHomNjbXwV3suVpkszHPegj6MSmRorgUuvh8u+Gf7kvB8bNaBpLGc84Ps2w==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "[1.9.1, 2.0.0)"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Transitive",
-        "resolved": "1.9.8",
-        "contentHash": "+HSX0XUkhZzKJS4v9i1rEgSlo3VgyljcXpTx4fD/gowmmMd7ZP7EyD769fCm2mIOnM0okJKuUvhPvChQhs8YCw==",
+        "resolved": "1.22.2",
+        "contentHash": "oenk5iemusMXQ3XvmlBXN6ycwZghH0EFCz2ZWeuSFzm1F7aNvl3EHJdQbiYTHievXoPnWXzW/diSQdKpvWZLwg==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Json": {
         "type": "Transitive",
-        "resolved": "1.9.8",
-        "contentHash": "QSHUipKdTLw7Xpe9AH/2u8tQKQoht185caOtTPGjWyTigmVChw7TF7BzTwA/mA3GSLSyD+IWwUgLdoh/9Ty2sQ==",
+        "resolved": "1.22.2",
+        "contentHash": "7MSOb/6cdAQpSie22BZSPxL0u5hkEVJL4oKn30jioX7rJtoWZgMd8LDVQP4w/JGpSYEWrNSs8o1g1Q1NHSStDg==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Multipart": {
         "type": "Transitive",
-        "resolved": "1.9.8",
-        "contentHash": "VgsA1bnsS0itQKiaR+YvxfM0NmEVN5o/GKkuadkPo0Q1F7QQHb9FNsZXn4mr9uIlCwrFAEBInMaVXGWPP4GJ0A==",
+        "resolved": "1.22.2",
+        "contentHash": "9tieLdQLSyk6ZhG1KIYfoSLWKyNkam9/sDqvI1XZcl962g/KzX6CCPh6H44Ub/D5KS6wDzz4YoWxjO9UXJ24cw==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Text": {
         "type": "Transitive",
-        "resolved": "1.9.8",
-        "contentHash": "Tsu+2TRo2GUhhoy0nVT7t/2OQ8MmkBHv59dSY/1UEyJz9dhiWJlaD8ykixX0mE4ppqD5QgkcbhaGNy0UL+jcAw==",
+        "resolved": "1.22.2",
+        "contentHash": "FIC94KqhgTb13FZ3jYvdaMT625oQ8TrXWZ157zDo9jnJ2SKELSBCs7qC2ZfEOJVApx4JruHfJ/r1dnqb4wj+8g==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
@@ -502,8 +512,8 @@
       },
       "Std.UriTemplate": {
         "type": "Transitive",
-        "resolved": "1.0.5",
-        "contentHash": "ry++apw4RKBw/9N8TQxnTTQYf/lgGGdn9+mq7AUMf860qD8STssQRe5tRX0NO99rGwpSRZzHO7u6ebQ/wahSNw=="
+        "resolved": "2.0.8",
+        "contentHash": "IAR4gJlLVD4r/FsU/rDb1+9sbB3/tCFVZz5IzlbM2yHoiUisBi5Ek/KXRUF7RcqNARka79EoaOz9INnXvQ/O6w=="
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
@@ -613,12 +623,12 @@
           "Microsoft.Extensions.Http.Resilience": "[9.8.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.4, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.4, )",
-          "Microsoft.Kiota.Abstractions": "[1.9.*, )",
-          "Microsoft.Kiota.Http.HttpClientLibrary": "[1.4.*, )",
-          "Microsoft.Kiota.Serialization.Form": "[1.4.0, )",
-          "Microsoft.Kiota.Serialization.Json": "[1.4.0, )",
-          "Microsoft.Kiota.Serialization.Multipart": "[1.4.0, )",
-          "Microsoft.Kiota.Serialization.Text": "[1.4.0, )",
+          "Microsoft.Kiota.Abstractions": "[1.22.*, )",
+          "Microsoft.Kiota.Http.HttpClientLibrary": "[1.22.*, )",
+          "Microsoft.Kiota.Serialization.Form": "[1.22.*, )",
+          "Microsoft.Kiota.Serialization.Json": "[1.22.*, )",
+          "Microsoft.Kiota.Serialization.Multipart": "[1.22.*, )",
+          "Microsoft.Kiota.Serialization.Text": "[1.22.*, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "Polly": "[8.5.2, )",
           "System.ComponentModel.Annotations": "[5.0.0, )",

--- a/Kinde.Api/Kinde.Api.csproj
+++ b/Kinde.Api/Kinde.Api.csproj
@@ -9,11 +9,11 @@
     <Product>Kinde Platform</Product>
     <Description>The Kinde .NET SDK allows developers to quickly and securely integrate a new or an existing .NET application to the Kinde platform.</Description>
     <Copyright>Kinde</Copyright>
-    <Version>2.0.4</Version>
+    <Version>2.1.0</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Kinde.Api.xml</DocumentationFile>
     <RepositoryUrl>https://github.com/kinde-oss/kinde-dotnet-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>Migration to Kiota-based API client with static facades for backward compatibility. Sync methods deprecated in favor of async. Internal implementation now uses Microsoft Kiota for cleaner API generation.</PackageReleaseNotes>
+    <PackageReleaseNotes>Adds Kinde invitation middleware. New management endpoints: api_keys, directories, subscribers, SAML connection options, MFA factor management. Introduces KindeAuthenticationException for auth-flow errors. Continues Kiota-based client buildout.</PackageReleaseNotes>
     <PackageTags>Kinde;Authentication;Billing;Feature;Flag;Startups</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>1591</NoWarn>
@@ -54,12 +54,12 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.8.0" />
     
     <!-- Kiota dependencies for API client generation -->
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.9.*" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.4.*" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.*" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.22.*" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.22.*" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.22.*" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.22.*" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.22.*" />
     
     <!-- AutoMapper for model translation between OpenAPI and Kiota models -->
     <PackageReference Include="AutoMapper" Version="13.0.*" />

--- a/Kinde.Api/packages.lock.json
+++ b/Kinde.Api/packages.lock.json
@@ -103,56 +103,61 @@
       },
       "Microsoft.Kiota.Abstractions": {
         "type": "Direct",
-        "requested": "[1.9.*, )",
-        "resolved": "1.9.12",
-        "contentHash": "UtQAwW+PGJRw58zjQt3GNB4TuW3wXvSbyYrgmMXDjkMIo2q6N3GRbZ3nvZPsArYA0q1UdonxkuTB2kYOyC9JWQ==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "xktJuKVMXfcX9LJR0QH8gwbZ2WO+WrqTujCPtN13Y6GfLaB7wV0v1pv3hdO1Fek2/vKRpALhbdRYmFNoyzO1Sg==",
         "dependencies": {
-          "Std.UriTemplate": "1.0.5"
+          "Std.UriTemplate": "2.0.8"
         }
       },
       "Microsoft.Kiota.Http.HttpClientLibrary": {
         "type": "Direct",
-        "requested": "[1.4.*, )",
-        "resolved": "1.4.3",
-        "contentHash": "axLzUosoRzLoC67RDuzzjSyGaY9Daw7TrCKOmXRosbWSa/Vy7bm1m5OI+pmPcL95EyCq1S9Y2Pmdl/qJQL1SRA==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "t3rPJbiLKBuvFQoCK/wmgwSjRmvEHomNjbXwV3suVpkszHPegj6MSmRorgUuvh8u+Gf7kvB8bNaBpLGc84Ps2w==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "[1.9.1, 2.0.0)"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.9.8",
-        "contentHash": "+HSX0XUkhZzKJS4v9i1rEgSlo3VgyljcXpTx4fD/gowmmMd7ZP7EyD769fCm2mIOnM0okJKuUvhPvChQhs8YCw==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "oenk5iemusMXQ3XvmlBXN6ycwZghH0EFCz2ZWeuSFzm1F7aNvl3EHJdQbiYTHievXoPnWXzW/diSQdKpvWZLwg==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Json": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.9.8",
-        "contentHash": "QSHUipKdTLw7Xpe9AH/2u8tQKQoht185caOtTPGjWyTigmVChw7TF7BzTwA/mA3GSLSyD+IWwUgLdoh/9Ty2sQ==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "7MSOb/6cdAQpSie22BZSPxL0u5hkEVJL4oKn30jioX7rJtoWZgMd8LDVQP4w/JGpSYEWrNSs8o1g1Q1NHSStDg==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Multipart": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.9.8",
-        "contentHash": "VgsA1bnsS0itQKiaR+YvxfM0NmEVN5o/GKkuadkPo0Q1F7QQHb9FNsZXn4mr9uIlCwrFAEBInMaVXGWPP4GJ0A==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "9tieLdQLSyk6ZhG1KIYfoSLWKyNkam9/sDqvI1XZcl962g/KzX6CCPh6H44Ub/D5KS6wDzz4YoWxjO9UXJ24cw==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Text": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.9.8",
-        "contentHash": "Tsu+2TRo2GUhhoy0nVT7t/2OQ8MmkBHv59dSY/1UEyJz9dhiWJlaD8ykixX0mE4ppqD5QgkcbhaGNy0UL+jcAw==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "FIC94KqhgTb13FZ3jYvdaMT625oQ8TrXWZ157zDo9jnJ2SKELSBCs7qC2ZfEOJVApx4JruHfJ/r1dnqb4wj+8g==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Newtonsoft.Json": {
@@ -408,6 +413,11 @@
           "Microsoft.IdentityModel.Logging": "8.8.0"
         }
       },
+      "Microsoft.IO.RecyclableMemoryStream": {
+        "type": "Transitive",
+        "resolved": "3.0.1",
+        "contentHash": "s/s20YTVY9r9TPfTrN5g8zPF1YhwxyqO6PxUkrYTGI2B+OGPe9AdajWZrLhFqXIvqIW23fnUE4+ztrUWNU1+9g=="
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.5.2",
@@ -434,8 +444,8 @@
       },
       "Std.UriTemplate": {
         "type": "Transitive",
-        "resolved": "1.0.5",
-        "contentHash": "ry++apw4RKBw/9N8TQxnTTQYf/lgGGdn9+mq7AUMf860qD8STssQRe5tRX0NO99rGwpSRZzHO7u6ebQ/wahSNw=="
+        "resolved": "2.0.8",
+        "contentHash": "IAR4gJlLVD4r/FsU/rDb1+9sbB3/tCFVZz5IzlbM2yHoiUisBi5Ek/KXRUF7RcqNARka79EoaOz9INnXvQ/O6w=="
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",

--- a/src/Kiota.Api/Kiota.Api.csproj
+++ b/src/Kiota.Api/Kiota.Api.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.9.*" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.4.*" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.*" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.22.*" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.22.*" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.22.*" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.22.*" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.22.*" />
   </ItemGroup>
 
 </Project>

--- a/src/Kiota.Api/packages.lock.json
+++ b/src/Kiota.Api/packages.lock.json
@@ -4,62 +4,77 @@
     "net8.0": {
       "Microsoft.Kiota.Abstractions": {
         "type": "Direct",
-        "requested": "[1.9.*, )",
-        "resolved": "1.9.12",
-        "contentHash": "UtQAwW+PGJRw58zjQt3GNB4TuW3wXvSbyYrgmMXDjkMIo2q6N3GRbZ3nvZPsArYA0q1UdonxkuTB2kYOyC9JWQ==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "xktJuKVMXfcX9LJR0QH8gwbZ2WO+WrqTujCPtN13Y6GfLaB7wV0v1pv3hdO1Fek2/vKRpALhbdRYmFNoyzO1Sg==",
         "dependencies": {
-          "Std.UriTemplate": "1.0.5"
+          "Std.UriTemplate": "2.0.8"
         }
       },
       "Microsoft.Kiota.Http.HttpClientLibrary": {
         "type": "Direct",
-        "requested": "[1.4.*, )",
-        "resolved": "1.4.3",
-        "contentHash": "axLzUosoRzLoC67RDuzzjSyGaY9Daw7TrCKOmXRosbWSa/Vy7bm1m5OI+pmPcL95EyCq1S9Y2Pmdl/qJQL1SRA==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "t3rPJbiLKBuvFQoCK/wmgwSjRmvEHomNjbXwV3suVpkszHPegj6MSmRorgUuvh8u+Gf7kvB8bNaBpLGc84Ps2w==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "[1.9.1, 2.0.0)"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.9.8",
-        "contentHash": "+HSX0XUkhZzKJS4v9i1rEgSlo3VgyljcXpTx4fD/gowmmMd7ZP7EyD769fCm2mIOnM0okJKuUvhPvChQhs8YCw==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "oenk5iemusMXQ3XvmlBXN6ycwZghH0EFCz2ZWeuSFzm1F7aNvl3EHJdQbiYTHievXoPnWXzW/diSQdKpvWZLwg==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Json": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.9.8",
-        "contentHash": "QSHUipKdTLw7Xpe9AH/2u8tQKQoht185caOtTPGjWyTigmVChw7TF7BzTwA/mA3GSLSyD+IWwUgLdoh/9Ty2sQ==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "7MSOb/6cdAQpSie22BZSPxL0u5hkEVJL4oKn30jioX7rJtoWZgMd8LDVQP4w/JGpSYEWrNSs8o1g1Q1NHSStDg==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Multipart": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.9.8",
-        "contentHash": "VgsA1bnsS0itQKiaR+YvxfM0NmEVN5o/GKkuadkPo0Q1F7QQHb9FNsZXn4mr9uIlCwrFAEBInMaVXGWPP4GJ0A==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "9tieLdQLSyk6ZhG1KIYfoSLWKyNkam9/sDqvI1XZcl962g/KzX6CCPh6H44Ub/D5KS6wDzz4YoWxjO9UXJ24cw==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Text": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.9.8",
-        "contentHash": "Tsu+2TRo2GUhhoy0nVT7t/2OQ8MmkBHv59dSY/1UEyJz9dhiWJlaD8ykixX0mE4ppqD5QgkcbhaGNy0UL+jcAw==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "FIC94KqhgTb13FZ3jYvdaMT625oQ8TrXWZ157zDo9jnJ2SKELSBCs7qC2ZfEOJVApx4JruHfJ/r1dnqb4wj+8g==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg=="
+      },
+      "Microsoft.IO.RecyclableMemoryStream": {
+        "type": "Transitive",
+        "resolved": "3.0.1",
+        "contentHash": "s/s20YTVY9r9TPfTrN5g8zPF1YhwxyqO6PxUkrYTGI2B+OGPe9AdajWZrLhFqXIvqIW23fnUE4+ztrUWNU1+9g=="
       },
       "Std.UriTemplate": {
         "type": "Transitive",
-        "resolved": "1.0.5",
-        "contentHash": "ry++apw4RKBw/9N8TQxnTTQYf/lgGGdn9+mq7AUMf860qD8STssQRe5tRX0NO99rGwpSRZzHO7u6ebQ/wahSNw=="
+        "resolved": "2.0.8",
+        "contentHash": "IAR4gJlLVD4r/FsU/rDb1+9sbB3/tCFVZz5IzlbM2yHoiUisBi5Ek/KXRUF7RcqNARka79EoaOz9INnXvQ/O6w=="
       }
     }
   }

--- a/tests/KiotaTests/KiotaTests.csproj
+++ b/tests/KiotaTests/KiotaTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="xunit" Version="2.8.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.10.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Kiota.Api\Kiota.Api.csproj" />

--- a/tests/KiotaTests/packages.lock.json
+++ b/tests/KiotaTests/packages.lock.json
@@ -4,11 +4,11 @@
     "net8.0": {
       "Microsoft.Kiota.Abstractions": {
         "type": "Direct",
-        "requested": "[1.10.0, )",
-        "resolved": "1.10.0",
-        "contentHash": "aozrFiATyQ4A4LGy0bjhSZ/hOnkdC0zT/n4UGKtyqef1UMv/vmcDMDgGC1Jp8Z1BMOJdnsZkmC2Fn6SWS5KDDw==",
+        "requested": "[1.22.*, )",
+        "resolved": "1.22.2",
+        "contentHash": "xktJuKVMXfcX9LJR0QH8gwbZ2WO+WrqTujCPtN13Y6GfLaB7wV0v1pv3hdO1Fek2/vKRpALhbdRYmFNoyzO1Sg==",
         "dependencies": {
-          "Std.UriTemplate": "1.0.5"
+          "Std.UriTemplate": "2.0.8"
         }
       },
       "Microsoft.NET.Test.Sdk": {
@@ -60,44 +60,59 @@
         "resolved": "17.10.0",
         "contentHash": "yC7oSlnR54XO5kOuHlVOKtxomNNN1BWXX8lK1G2jaPXT9sUok7kCOoA4Pgs0qyFaCtMrNsprztYMeoEGqCm4uA=="
       },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg=="
+      },
+      "Microsoft.IO.RecyclableMemoryStream": {
+        "type": "Transitive",
+        "resolved": "3.0.1",
+        "contentHash": "s/s20YTVY9r9TPfTrN5g8zPF1YhwxyqO6PxUkrYTGI2B+OGPe9AdajWZrLhFqXIvqIW23fnUE4+ztrUWNU1+9g=="
+      },
       "Microsoft.Kiota.Http.HttpClientLibrary": {
         "type": "Transitive",
-        "resolved": "1.4.3",
-        "contentHash": "axLzUosoRzLoC67RDuzzjSyGaY9Daw7TrCKOmXRosbWSa/Vy7bm1m5OI+pmPcL95EyCq1S9Y2Pmdl/qJQL1SRA==",
+        "resolved": "1.22.2",
+        "contentHash": "t3rPJbiLKBuvFQoCK/wmgwSjRmvEHomNjbXwV3suVpkszHPegj6MSmRorgUuvh8u+Gf7kvB8bNaBpLGc84Ps2w==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "[1.9.1, 2.0.0)"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Transitive",
-        "resolved": "1.9.8",
-        "contentHash": "+HSX0XUkhZzKJS4v9i1rEgSlo3VgyljcXpTx4fD/gowmmMd7ZP7EyD769fCm2mIOnM0okJKuUvhPvChQhs8YCw==",
+        "resolved": "1.22.2",
+        "contentHash": "oenk5iemusMXQ3XvmlBXN6ycwZghH0EFCz2ZWeuSFzm1F7aNvl3EHJdQbiYTHievXoPnWXzW/diSQdKpvWZLwg==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Json": {
         "type": "Transitive",
-        "resolved": "1.9.8",
-        "contentHash": "QSHUipKdTLw7Xpe9AH/2u8tQKQoht185caOtTPGjWyTigmVChw7TF7BzTwA/mA3GSLSyD+IWwUgLdoh/9Ty2sQ==",
+        "resolved": "1.22.2",
+        "contentHash": "7MSOb/6cdAQpSie22BZSPxL0u5hkEVJL4oKn30jioX7rJtoWZgMd8LDVQP4w/JGpSYEWrNSs8o1g1Q1NHSStDg==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Multipart": {
         "type": "Transitive",
-        "resolved": "1.9.8",
-        "contentHash": "VgsA1bnsS0itQKiaR+YvxfM0NmEVN5o/GKkuadkPo0Q1F7QQHb9FNsZXn4mr9uIlCwrFAEBInMaVXGWPP4GJ0A==",
+        "resolved": "1.22.2",
+        "contentHash": "9tieLdQLSyk6ZhG1KIYfoSLWKyNkam9/sDqvI1XZcl962g/KzX6CCPh6H44Ub/D5KS6wDzz4YoWxjO9UXJ24cw==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.Kiota.Serialization.Text": {
         "type": "Transitive",
-        "resolved": "1.9.8",
-        "contentHash": "Tsu+2TRo2GUhhoy0nVT7t/2OQ8MmkBHv59dSY/1UEyJz9dhiWJlaD8ykixX0mE4ppqD5QgkcbhaGNy0UL+jcAw==",
+        "resolved": "1.22.2",
+        "contentHash": "FIC94KqhgTb13FZ3jYvdaMT625oQ8TrXWZ157zDo9jnJ2SKELSBCs7qC2ZfEOJVApx4JruHfJ/r1dnqb4wj+8g==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.9.8"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "Microsoft.Kiota.Abstractions": "1.22.2"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
@@ -124,8 +139,8 @@
       },
       "Std.UriTemplate": {
         "type": "Transitive",
-        "resolved": "1.0.5",
-        "contentHash": "ry++apw4RKBw/9N8TQxnTTQYf/lgGGdn9+mq7AUMf860qD8STssQRe5tRX0NO99rGwpSRZzHO7u6ebQ/wahSNw=="
+        "resolved": "2.0.8",
+        "contentHash": "IAR4gJlLVD4r/FsU/rDb1+9sbB3/tCFVZz5IzlbM2yHoiUisBi5Ek/KXRUF7RcqNARka79EoaOz9INnXvQ/O6w=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -180,12 +195,12 @@
       "kiota.api": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "[1.9.*, )",
-          "Microsoft.Kiota.Http.HttpClientLibrary": "[1.4.*, )",
-          "Microsoft.Kiota.Serialization.Form": "[1.4.0, )",
-          "Microsoft.Kiota.Serialization.Json": "[1.4.0, )",
-          "Microsoft.Kiota.Serialization.Multipart": "[1.4.0, )",
-          "Microsoft.Kiota.Serialization.Text": "[1.4.0, )"
+          "Microsoft.Kiota.Abstractions": "[1.22.*, )",
+          "Microsoft.Kiota.Http.HttpClientLibrary": "[1.22.*, )",
+          "Microsoft.Kiota.Serialization.Form": "[1.22.*, )",
+          "Microsoft.Kiota.Serialization.Json": "[1.22.*, )",
+          "Microsoft.Kiota.Serialization.Multipart": "[1.22.*, )",
+          "Microsoft.Kiota.Serialization.Text": "[1.22.*, )"
         }
       }
     }


### PR DESCRIPTION
# Explain your changes

Release **v2.1.0** - This PR lands the version bump, Kiota dep upgrade, and lockfile updates on `main`.

Upgrades `Microsoft.Kiota.*` from `1.9.x`/`1.4.x` → `1.22.x` to pick up the fix for [GHSA-7j59-v9qr-6fq9](https://github.com/advisories/GHSA-7j59-v9qr-6fq9).


# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
