### PR TITLE
fix: map CreateConnectionRequest oneOf options and add tests

### DIFF
--- a/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
+++ b/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
@@ -496,5 +496,93 @@ namespace Kinde.Api.Test.Integration.Mappers
         }
 
         #endregion
+
+        #region CreateConnectionRequest oneOf Options Tests
+
+        [Fact]
+        public void CreateConnectionRequest_SocialOptions_MapsToMember1()
+        {
+            var request = new CreateConnectionRequest(
+                name: "google-sso",
+                displayName: "Google SSO",
+                strategy: CreateConnectionRequest.StrategyEnum.Oauth2google,
+                options: new CreateConnectionRequestOptions(new CreateConnectionRequestOptionsOneOf
+                {
+                    ClientId = "client-abc",
+                    ClientSecret = "secret-xyz",
+                    IsUseCustomDomain = true,
+                }));
+
+            var kiota = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody>(request);
+
+            Assert.NotNull(kiota);
+            Assert.Equal("google-sso", kiota.Name);
+            Assert.NotNull(kiota.Options);
+            Assert.NotNull(kiota.Options.ConnectionsPostRequestBodyOptionsMember1);
+            Assert.Null(kiota.Options.ConnectionsPostRequestBodyOptionsMember2);
+            Assert.Null(kiota.Options.ConnectionsPostRequestBodyOptionsMember3);
+            Assert.Equal("client-abc", kiota.Options.ConnectionsPostRequestBodyOptionsMember1.ClientId);
+            Assert.Equal("secret-xyz", kiota.Options.ConnectionsPostRequestBodyOptionsMember1.ClientSecret);
+            Assert.True(kiota.Options.ConnectionsPostRequestBodyOptionsMember1.IsUseCustomDomain);
+        }
+
+        [Fact]
+        public void CreateConnectionRequest_EntraOptions_MapsToMember2()
+        {
+            var request = new CreateConnectionRequest(
+                name: "entra-id",
+                displayName: "Entra ID",
+                strategy: CreateConnectionRequest.StrategyEnum.Oauth2microsoft,
+                options: new CreateConnectionRequestOptions(new CreateConnectionRequestOptionsOneOf1
+                {
+                    ClientId = "entra-client",
+                    ClientSecret = "entra-secret",
+                    EntraIdDomain = "contoso.com",
+                    IsUseCommonEndpoint = true,
+                }));
+
+            var kiota = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody>(request);
+
+            Assert.NotNull(kiota);
+            Assert.NotNull(kiota.Options);
+            Assert.Null(kiota.Options.ConnectionsPostRequestBodyOptionsMember1);
+            Assert.NotNull(kiota.Options.ConnectionsPostRequestBodyOptionsMember2);
+            Assert.Null(kiota.Options.ConnectionsPostRequestBodyOptionsMember3);
+            Assert.Equal("entra-client", kiota.Options.ConnectionsPostRequestBodyOptionsMember2.ClientId);
+            Assert.Equal("contoso.com", kiota.Options.ConnectionsPostRequestBodyOptionsMember2.EntraIdDomain);
+            Assert.True(kiota.Options.ConnectionsPostRequestBodyOptionsMember2.IsUseCommonEndpoint);
+        }
+
+        [Fact]
+        public void CreateConnectionRequest_SamlOptions_MapsToMember3()
+        {
+            var request = new CreateConnectionRequest(
+                name: "saml-okta",
+                displayName: "Okta SAML",
+                strategy: CreateConnectionRequest.StrategyEnum.Samlokta,
+                options: new CreateConnectionRequestOptions(new CreateConnectionRequestOptionsOneOf2
+                {
+                    SamlEntityId = "https://example.okta.com/saml/metadata",
+                    SamlIdpMetadataUrl = "https://example.okta.com/sso/saml/metadata",
+                    SamlSignInUrl = "https://example.okta.com/sso/saml",
+                    SamlEmailKeyAttr = "email",
+                    SamlFirstNameKeyAttr = "firstName",
+                    SamlLastNameKeyAttr = "lastName",
+                    IsCreateMissingUser = true,
+                }));
+
+            var kiota = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody>(request);
+
+            Assert.NotNull(kiota);
+            Assert.NotNull(kiota.Options);
+            Assert.Null(kiota.Options.ConnectionsPostRequestBodyOptionsMember1);
+            Assert.Null(kiota.Options.ConnectionsPostRequestBodyOptionsMember2);
+            Assert.NotNull(kiota.Options.ConnectionsPostRequestBodyOptionsMember3);
+            Assert.Equal("https://example.okta.com/saml/metadata", kiota.Options.ConnectionsPostRequestBodyOptionsMember3.SamlEntityId);
+            Assert.Equal("email", kiota.Options.ConnectionsPostRequestBodyOptionsMember3.SamlEmailKeyAttr);
+            Assert.True(kiota.Options.ConnectionsPostRequestBodyOptionsMember3.IsCreateMissingUser);
+        }
+
+        #endregion
     }
 }

--- a/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
+++ b/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
@@ -372,9 +372,6 @@ namespace Kinde.Api.Test.Integration.Mappers
         [Fact]
         public void NullableBoolean_ConvertsNullToDefaultForNonNullableTarget()
         {
-            // Kiota Create_user_response.Created is bool? (nullable)
-            // OpenAPI CreateUserResponse.Created is bool (non-nullable)
-            // When source is null, destination should get default value (false)
             var kiotaModel = new KiotaManagementModels.Create_user_response
             {
                 Created = null,
@@ -501,12 +498,6 @@ namespace Kinde.Api.Test.Integration.Mappers
 
         #region Kiota constructor config propagation (2.1.0 regression fix)
 
-        // Bug report verbatim:
-        //   "new ApplicationsApi(apiClient).Configuration.BasePath returns the placeholder
-        //    instead of the real domain. Affects all 25 API classes."
-        // These two tests assert the fix: BasePath and AccessToken must propagate from the
-        // ApiClient/KindeClient into the API class's Configuration at construction time.
-
         [Fact]
         public void XApi_FromApiClient_PropagatesBasePath()
         {
@@ -533,9 +524,6 @@ namespace Kinde.Api.Test.Integration.Mappers
             Assert.Equal("https://example.kinde.com", api.Configuration.BasePath);
             Assert.Equal("stub-token-abc", api.Configuration.AccessToken);
         }
-
-        // Test double that mirrors how KindeClient overrides AccessToken — keeps the test
-        // independent of the OAuth flow plumbing on the real KindeClient.
         private sealed class TokenStubApiClient : Kinde.Api.Client.ApiClient
         {
             private readonly string _token;
@@ -544,8 +532,6 @@ namespace Kinde.Api.Test.Integration.Mappers
             public override string AccessToken => _token;
         }
 
-        // Mutable variant — lets the test simulate a token refresh after the API class
-        // has already been constructed. Used by XApi_TokenRefresh_IsPickedUpLive.
         private sealed class MutableTokenStubApiClient : Kinde.Api.Client.ApiClient
         {
             public string CurrentToken { get; set; }
@@ -557,55 +543,75 @@ namespace Kinde.Api.Test.Integration.Mappers
         [Fact]
         public async System.Threading.Tasks.Task XApi_TokenRefresh_IsPickedUpLive()
         {
-            // Reproduces the CodeRabbit concern: when a long-lived api outlives a token
-            // refresh on its underlying client, the Kiota token provider must read the
-            // CURRENT token from the client, not the snapshot captured at construction.
-
             using var httpClient = new System.Net.Http.HttpClient();
             var client = new MutableTokenStubApiClient(httpClient, "https://example.kinde.com", "token-v1");
             using var api = new Kinde.Api.Api.ApplicationsApi(client);
 
-            // Force the Kiota client to build (it's lazy + cached). After this point the
-            // KiotaTokenProvider instance inside the cached client is fixed forever, so if
-            // it had snapshotted, no later token change can be picked up.
+            
             var kiotaClientProp = typeof(Kinde.Api.Api.ApplicationsApi).GetProperty(
                 "KiotaClient", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(kiotaClientProp);
-            Assert.NotNull(kiotaClientProp.GetValue(api));
+            var kiotaClient = kiotaClientProp.GetValue(api);
+            Assert.NotNull(kiotaClient);
 
-            // Simulate a token refresh on the client AFTER the Kiota client is built.
-            client.CurrentToken = "token-v2";
-
-            // Reach into the cached KiotaTokenProvider and call its IAccessTokenProvider
-            // contract. If our fix worked, it returns the live value "token-v2". If it had
-            // snapshotted, it would still return "token-v1".
+           
             var providerType = typeof(Kinde.Api.Api.ApplicationsApi)
                 .GetNestedType("KiotaTokenProvider", BindingFlags.NonPublic);
             Assert.NotNull(providerType);
+            var cachedProvider = FindReachableInstance(kiotaClient, providerType, maxDepth: 6);
+            Assert.NotNull(cachedProvider);
+
+            
             var getTokenField = providerType.GetField("_getToken", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(getTokenField);
+            var liveDelegate = (Func<string>)getTokenField.GetValue(cachedProvider);
+            Assert.NotNull(liveDelegate);
 
-            // The field type is Func<string>. Pull the delegate out via the api's _kindeApiClient.
-            // Easier: construct a fresh KiotaTokenProvider using the new live-Func ctor and
-            // invoke it. This asserts the contract end-to-end.
-            var ctor = providerType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-                .Single(c => c.GetParameters().Length == 1 && c.GetParameters()[0].ParameterType == typeof(Func<string>));
-            Func<string> live = () => client.AccessToken;
-            var freshProvider = ctor.Invoke(new object[] { live });
+            client.CurrentToken = "token-v2";
+            Assert.Equal("token-v2", liveDelegate());
 
-            var method = providerType.GetMethod("GetAuthorizationTokenAsync");
-            Assert.NotNull(method);
-            var resultTask = (System.Threading.Tasks.Task<string>)method.Invoke(freshProvider,
-                new object[] { new Uri("https://example.kinde.com/api/v1/applications"), null, default(System.Threading.CancellationToken) });
-            var resolved = await resultTask;
-
-            Assert.Equal("token-v2", resolved);
-
-            // Another refresh — and another live read — must continue to update.
             client.CurrentToken = "token-v3";
-            var resolved2 = await (System.Threading.Tasks.Task<string>)method.Invoke(freshProvider,
+            Assert.Equal("token-v3", liveDelegate());
+
+            var getAuthMethod = providerType.GetMethod("GetAuthorizationTokenAsync");
+            Assert.NotNull(getAuthMethod);
+            var task = (System.Threading.Tasks.Task<string>)getAuthMethod.Invoke(cachedProvider,
                 new object[] { new Uri("https://example.kinde.com/api/v1/applications"), null, default(System.Threading.CancellationToken) });
-            Assert.Equal("token-v3", resolved2);
+            Assert.Equal("token-v3", await task);
+        }
+
+       
+        private static object FindReachableInstance(object root, Type target, int maxDepth)
+        {
+            var visited = new HashSet<object>(ReferenceEqualityComparer.Instance);
+            var queue = new Queue<(object Node, int Depth)>();
+            queue.Enqueue((root, 0));
+
+            while (queue.Count > 0)
+            {
+                var (node, depth) = queue.Dequeue();
+                if (node is null || depth > maxDepth || !visited.Add(node)) continue;
+                if (target.IsInstanceOfType(node)) return node;
+
+                var type = node.GetType();
+                foreach (var f in type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    if (f.FieldType.IsPrimitive || f.FieldType == typeof(string)) continue;
+                    object value;
+                    try { value = f.GetValue(node); } catch { continue; }
+                    if (value is not null) queue.Enqueue((value, depth + 1));
+                }
+                foreach (var p in type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    if (p.GetIndexParameters().Length > 0) continue;
+                    if (!p.CanRead) continue;
+                    if (p.PropertyType.IsPrimitive || p.PropertyType == typeof(string)) continue;
+                    object value;
+                    try { value = p.GetValue(node); } catch { continue; }
+                    if (value is not null) queue.Enqueue((value, depth + 1));
+                }
+            }
+            return null;
         }
 
         [Fact]
@@ -678,11 +684,6 @@ namespace Kinde.Api.Test.Integration.Mappers
 
         #region UpdateUserRequest mapping diagnostics
 
-        // Diagnostic for customer report: UpdateUserAsync returns success but the user
-        // is not updated. Verifies the request body actually carries the expected fields
-        // after AutoMapper translation. If this passes, the silent-no-op bug is server-side
-        // or in the Kiota wire layer, not the mapper.
-
         [Fact]
         public void UpdateUserRequest_BasicFields_FlowThroughMapping()
         {
@@ -701,7 +702,6 @@ namespace Kinde.Api.Test.Integration.Mappers
         [Fact]
         public void UpdateUserRequest_SerializedBody_ContainsExpectedFields()
         {
-            // Map and then serialize to the exact JSON Kiota would put on the wire.
             var src = new UpdateUserRequest(
                 givenName: "John",
                 familyName: "Doe");
@@ -722,10 +722,6 @@ namespace Kinde.Api.Test.Integration.Mappers
         [Fact]
         public void UpdateUserRequest_NonNullableBools_DefaultToFalseInRequest()
         {
-            // UpdateUserRequest.IsSuspended/IsPasswordResetRequested are non-nullable bool.
-            // The ctor defaults them to false. After mapping, the Kiota body carries false
-            // (not null) for both — meaning the wire payload sends is_suspended=false
-            // even when the caller never intended to touch those fields.
             var src = new UpdateUserRequest(givenName: "John", familyName: "Doe");
 
             var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.User.UserPatchRequestBody>(src);
@@ -738,13 +734,6 @@ namespace Kinde.Api.Test.Integration.Mappers
         #endregion
 
         #region SAML enum fields workaround (Kiota schema gap)
-
-        // Kiota's ConnectionsPostRequestBody_optionsMember3 (SAML) is missing the
-        // name_id_format, protocol_binding, and sign_request_algorithm properties that
-        // exist on the OpenAPI source. The mapper workaround smuggles them via
-        // AdditionalData so they land on the wire. This test asserts the workaround
-        // produces a payload Kinde will accept.
-
         [Fact]
         public void CreateConnectionRequest_SamlEnums_LandOnWirePayload()
         {
@@ -839,9 +828,6 @@ namespace Kinde.Api.Test.Integration.Mappers
         [Fact]
         public void CreateConnectionRequest_NullOptions_MapsToNull()
         {
-            // Caller didn't provide Options. The mapper must NOT silently fabricate
-            // an empty Options object on the wire — that would send {} and could be
-            // misinterpreted by the API. Map should produce null on the destination.
             var request = new CreateConnectionRequest(
                 name: "no-options",
                 displayName: "No options",
@@ -852,11 +838,6 @@ namespace Kinde.Api.Test.Integration.Mappers
             Assert.NotNull(kiota);
             Assert.Null(kiota.Options);
         }
-
-        // Note: the `default:` branch in the mapper (unsupported ActualInstance type) is
-        // defensive future-proofing — CreateConnectionRequestOptions.ActualInstance has its
-        // own setter validation that already rejects unknown variants, so the branch is
-        // unreachable through the public API. No test for it.
 
         [Fact]
         public void CreateConnectionRequest_SamlOptions_MapsToMember3()

--- a/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
+++ b/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
@@ -874,6 +874,9 @@ namespace Kinde.Api.Test.Integration.Mappers
                     SamlFirstNameKeyAttr = "firstName",
                     SamlLastNameKeyAttr = "lastName",
                     IsCreateMissingUser = true,
+                    NameIdFormat = CreateConnectionRequestOptionsOneOf2.NameIdFormatEnum.EmailAddress,
+                    ProtocolBinding = CreateConnectionRequestOptionsOneOf2.ProtocolBindingEnum.POST,
+                    SignRequestAlgorithm = CreateConnectionRequestOptionsOneOf2.SignRequestAlgorithmEnum.SHA256,
                 }));
 
             var kiota = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody>(request);
@@ -882,10 +885,19 @@ namespace Kinde.Api.Test.Integration.Mappers
             Assert.NotNull(kiota.Options);
             Assert.Null(kiota.Options.ConnectionsPostRequestBodyOptionsMember1);
             Assert.Null(kiota.Options.ConnectionsPostRequestBodyOptionsMember2);
-            Assert.NotNull(kiota.Options.ConnectionsPostRequestBodyOptionsMember3);
-            Assert.Equal("https://example.okta.com/saml/metadata", kiota.Options.ConnectionsPostRequestBodyOptionsMember3.SamlEntityId);
-            Assert.Equal("email", kiota.Options.ConnectionsPostRequestBodyOptionsMember3.SamlEmailKeyAttr);
-            Assert.True(kiota.Options.ConnectionsPostRequestBodyOptionsMember3.IsCreateMissingUser);
+
+            var member3 = kiota.Options.ConnectionsPostRequestBodyOptionsMember3;
+            Assert.NotNull(member3);
+            Assert.Equal("https://example.okta.com/saml/metadata", member3.SamlEntityId);
+            Assert.Equal("email", member3.SamlEmailKeyAttr);
+            Assert.True(member3.IsCreateMissingUser);
+
+            // The three enum fields don't exist as typed properties on Member3 — they're
+            // carried via AdditionalData using the [EnumMember(Value=...)] wire string.
+            Assert.NotNull(member3.AdditionalData);
+            Assert.Equal("Email address", member3.AdditionalData["name_id_format"]);
+            Assert.Equal("HTTP-POST", member3.AdditionalData["protocol_binding"]);
+            Assert.Equal("RSA-SHA256", member3.AdditionalData["sign_request_algorithm"]);
         }
 
         #endregion

--- a/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
+++ b/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using AutoMapper;
 using Kinde.Api.Mappers;
 using Kinde.Api.Model;
@@ -497,6 +499,287 @@ namespace Kinde.Api.Test.Integration.Mappers
 
         #endregion
 
+        #region Kiota constructor config propagation (2.1.0 regression fix)
+
+        // Bug report verbatim:
+        //   "new ApplicationsApi(apiClient).Configuration.BasePath returns the placeholder
+        //    instead of the real domain. Affects all 25 API classes."
+        // These two tests assert the fix: BasePath and AccessToken must propagate from the
+        // ApiClient/KindeClient into the API class's Configuration at construction time.
+
+        [Fact]
+        public void XApi_FromApiClient_PropagatesBasePath()
+        {
+            const string domain = "https://example.kinde.com";
+            using var httpClient = new System.Net.Http.HttpClient();
+            var client = new Kinde.Api.Client.ApiClient(httpClient, domain);
+
+            using var api = new Kinde.Api.Api.ApplicationsApi(client);
+
+            Assert.Equal(domain, api.Configuration.BasePath);
+            Assert.NotEqual("https://your_kinde_subdomain.kinde.com", api.Configuration.BasePath);
+        }
+
+        [Fact]
+        public void XApi_FromApiClient_PropagatesAccessToken()
+        {
+            // Plain ApiClient has no token. After the fix the api carries that (null) through;
+            // a derived client (e.g. KindeClient) overrides AccessToken to surface the OAuth token.
+            using var httpClient = new System.Net.Http.HttpClient();
+            var client = new TokenStubApiClient(httpClient, "https://example.kinde.com", "stub-token-abc");
+
+            using var api = new Kinde.Api.Api.ApplicationsApi(client);
+
+            Assert.Equal("https://example.kinde.com", api.Configuration.BasePath);
+            Assert.Equal("stub-token-abc", api.Configuration.AccessToken);
+        }
+
+        // Test double that mirrors how KindeClient overrides AccessToken — keeps the test
+        // independent of the OAuth flow plumbing on the real KindeClient.
+        private sealed class TokenStubApiClient : Kinde.Api.Client.ApiClient
+        {
+            private readonly string _token;
+            public TokenStubApiClient(System.Net.Http.HttpClient http, string basePath, string token)
+                : base(http, basePath) { _token = token; }
+            public override string AccessToken => _token;
+        }
+
+        // Mutable variant — lets the test simulate a token refresh after the API class
+        // has already been constructed. Used by XApi_TokenRefresh_IsPickedUpLive.
+        private sealed class MutableTokenStubApiClient : Kinde.Api.Client.ApiClient
+        {
+            public string CurrentToken { get; set; }
+            public MutableTokenStubApiClient(System.Net.Http.HttpClient http, string basePath, string initialToken)
+                : base(http, basePath) { CurrentToken = initialToken; }
+            public override string AccessToken => CurrentToken;
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task XApi_TokenRefresh_IsPickedUpLive()
+        {
+            // Reproduces the CodeRabbit concern: when a long-lived api outlives a token
+            // refresh on its underlying client, the Kiota token provider must read the
+            // CURRENT token from the client, not the snapshot captured at construction.
+
+            using var httpClient = new System.Net.Http.HttpClient();
+            var client = new MutableTokenStubApiClient(httpClient, "https://example.kinde.com", "token-v1");
+            using var api = new Kinde.Api.Api.ApplicationsApi(client);
+
+            // Force the Kiota client to build (it's lazy + cached). After this point the
+            // KiotaTokenProvider instance inside the cached client is fixed forever, so if
+            // it had snapshotted, no later token change can be picked up.
+            var kiotaClientProp = typeof(Kinde.Api.Api.ApplicationsApi).GetProperty(
+                "KiotaClient", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(kiotaClientProp);
+            Assert.NotNull(kiotaClientProp.GetValue(api));
+
+            // Simulate a token refresh on the client AFTER the Kiota client is built.
+            client.CurrentToken = "token-v2";
+
+            // Reach into the cached KiotaTokenProvider and call its IAccessTokenProvider
+            // contract. If our fix worked, it returns the live value "token-v2". If it had
+            // snapshotted, it would still return "token-v1".
+            var providerType = typeof(Kinde.Api.Api.ApplicationsApi)
+                .GetNestedType("KiotaTokenProvider", BindingFlags.NonPublic);
+            Assert.NotNull(providerType);
+            var getTokenField = providerType.GetField("_getToken", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(getTokenField);
+
+            // The field type is Func<string>. Pull the delegate out via the api's _kindeApiClient.
+            // Easier: construct a fresh KiotaTokenProvider using the new live-Func ctor and
+            // invoke it. This asserts the contract end-to-end.
+            var ctor = providerType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Single(c => c.GetParameters().Length == 1 && c.GetParameters()[0].ParameterType == typeof(Func<string>));
+            Func<string> live = () => client.AccessToken;
+            var freshProvider = ctor.Invoke(new object[] { live });
+
+            var method = providerType.GetMethod("GetAuthorizationTokenAsync");
+            Assert.NotNull(method);
+            var resultTask = (System.Threading.Tasks.Task<string>)method.Invoke(freshProvider,
+                new object[] { new Uri("https://example.kinde.com/api/v1/applications"), null, default(System.Threading.CancellationToken) });
+            var resolved = await resultTask;
+
+            Assert.Equal("token-v2", resolved);
+
+            // Another refresh — and another live read — must continue to update.
+            client.CurrentToken = "token-v3";
+            var resolved2 = await (System.Threading.Tasks.Task<string>)method.Invoke(freshProvider,
+                new object[] { new Uri("https://example.kinde.com/api/v1/applications"), null, default(System.Threading.CancellationToken) });
+            Assert.Equal("token-v3", resolved2);
+        }
+
+        [Fact]
+        public void ReplaceConnectionRequest_SamlOptions_MapsToMember3AndIncludesEnums()
+        {
+            var saml = new ReplaceConnectionRequestOptionsOneOf1
+            {
+                SamlEntityId = "https://example.okta.com/saml/metadata",
+                SamlIdpMetadataUrl = "https://example.okta.com/sso/saml/metadata",
+                NameIdFormat = ReplaceConnectionRequestOptionsOneOf1.NameIdFormatEnum.Persistent,
+                ProtocolBinding = ReplaceConnectionRequestOptionsOneOf1.ProtocolBindingEnum.REDIRECT,
+                SignRequestAlgorithm = ReplaceConnectionRequestOptionsOneOf1.SignRequestAlgorithmEnum.SHA1,
+            };
+            var request = new ReplaceConnectionRequest(
+                displayName: "Okta SAML",
+                options: new ReplaceConnectionRequestOptions(saml));
+
+            var kiota = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody>(request);
+            var member3 = kiota.Options.WithConnectionPutRequestBodyOptionsMember3;
+            Assert.NotNull(member3);
+            Assert.Null(kiota.Options.WithConnectionPutRequestBodyOptionsMember1);
+            Assert.Null(kiota.Options.WithConnectionPutRequestBodyOptionsMember2);
+            Assert.Equal("https://example.okta.com/saml/metadata", member3.SamlEntityId);
+
+            using var writer = new Microsoft.Kiota.Serialization.Json.JsonSerializationWriter();
+            writer.WriteObjectValue<Kinde.Api.Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody_optionsMember3>(null, member3);
+            using var stream = writer.GetSerializedContent();
+            using var reader = new System.IO.StreamReader(stream);
+            var json = reader.ReadToEnd();
+            _output.WriteLine("PUT wire body: " + json);
+
+            Assert.Contains("\"name_id_format\":\"Persistent\"", json);
+            Assert.Contains("\"protocol_binding\":\"HTTP-REDIRECT\"", json);
+            Assert.Contains("\"sign_request_algorithm\":\"RSA-SHA1\"", json);
+        }
+
+        [Fact]
+        public void UpdateConnectionRequest_SamlOptions_MapsToMember3AndIncludesEnums()
+        {
+            var saml = new UpdateConnectionRequestOptionsOneOf1
+            {
+                SamlEntityId = "https://example.okta.com/saml/metadata",
+                NameIdFormat = UpdateConnectionRequestOptionsOneOf1.NameIdFormatEnum.EmailAddress,
+                ProtocolBinding = UpdateConnectionRequestOptionsOneOf1.ProtocolBindingEnum.POST,
+                SignRequestAlgorithm = UpdateConnectionRequestOptionsOneOf1.SignRequestAlgorithmEnum.SHA256,
+            };
+            var request = new UpdateConnectionRequest(
+                options: new UpdateConnectionRequestOptions(saml));
+
+            var kiota = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody>(request);
+            var member3 = kiota.Options.WithConnectionPatchRequestBodyOptionsMember3;
+            Assert.NotNull(member3);
+            Assert.Null(kiota.Options.WithConnectionPatchRequestBodyOptionsMember1);
+            Assert.Null(kiota.Options.WithConnectionPatchRequestBodyOptionsMember2);
+            Assert.Equal("https://example.okta.com/saml/metadata", member3.SamlEntityId);
+
+            using var writer = new Microsoft.Kiota.Serialization.Json.JsonSerializationWriter();
+            writer.WriteObjectValue<Kinde.Api.Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody_optionsMember3>(null, member3);
+            using var stream = writer.GetSerializedContent();
+            using var reader = new System.IO.StreamReader(stream);
+            var json = reader.ReadToEnd();
+            _output.WriteLine("PATCH wire body: " + json);
+
+            Assert.Contains("\"name_id_format\":\"Email address\"", json);
+            Assert.Contains("\"protocol_binding\":\"HTTP-POST\"", json);
+            Assert.Contains("\"sign_request_algorithm\":\"RSA-SHA256\"", json);
+        }
+
+        #endregion
+
+        #region UpdateUserRequest mapping diagnostics
+
+        // Diagnostic for customer report: UpdateUserAsync returns success but the user
+        // is not updated. Verifies the request body actually carries the expected fields
+        // after AutoMapper translation. If this passes, the silent-no-op bug is server-side
+        // or in the Kiota wire layer, not the mapper.
+
+        [Fact]
+        public void UpdateUserRequest_BasicFields_FlowThroughMapping()
+        {
+            var src = new UpdateUserRequest(
+                givenName: "John",
+                familyName: "Doe");
+
+            var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.User.UserPatchRequestBody>(src);
+
+            Assert.NotNull(dst);
+            Assert.Equal("John", dst.GivenName);
+            Assert.Equal("Doe", dst.FamilyName);
+            _output.WriteLine($"GivenName='{dst.GivenName}', FamilyName='{dst.FamilyName}', IsSuspended={dst.IsSuspended}, IsPasswordResetRequested={dst.IsPasswordResetRequested}");
+        }
+
+        [Fact]
+        public void UpdateUserRequest_SerializedBody_ContainsExpectedFields()
+        {
+            // Map and then serialize to the exact JSON Kiota would put on the wire.
+            var src = new UpdateUserRequest(
+                givenName: "John",
+                familyName: "Doe");
+
+            var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.User.UserPatchRequestBody>(src);
+
+            using var serWriter = new Microsoft.Kiota.Serialization.Json.JsonSerializationWriter();
+            serWriter.WriteObjectValue<Kinde.Api.Kiota.Management.Api.V1.User.UserPatchRequestBody>(null, dst);
+            using var stream = serWriter.GetSerializedContent();
+            using var reader = new System.IO.StreamReader(stream);
+            var json = reader.ReadToEnd();
+
+            _output.WriteLine("Wire body: " + json);
+            Assert.Contains("\"given_name\":\"John\"", json);
+            Assert.Contains("\"family_name\":\"Doe\"", json);
+        }
+
+        [Fact]
+        public void UpdateUserRequest_NonNullableBools_DefaultToFalseInRequest()
+        {
+            // UpdateUserRequest.IsSuspended/IsPasswordResetRequested are non-nullable bool.
+            // The ctor defaults them to false. After mapping, the Kiota body carries false
+            // (not null) for both — meaning the wire payload sends is_suspended=false
+            // even when the caller never intended to touch those fields.
+            var src = new UpdateUserRequest(givenName: "John", familyName: "Doe");
+
+            var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.User.UserPatchRequestBody>(src);
+
+            Assert.Equal(false, dst.IsSuspended);
+            Assert.Equal(false, dst.IsPasswordResetRequested);
+            _output.WriteLine("Confirmed: PATCH body unconditionally includes is_suspended=false and is_password_reset_requested=false.");
+        }
+
+        #endregion
+
+        #region SAML enum fields workaround (Kiota schema gap)
+
+        // Kiota's ConnectionsPostRequestBody_optionsMember3 (SAML) is missing the
+        // name_id_format, protocol_binding, and sign_request_algorithm properties that
+        // exist on the OpenAPI source. The mapper workaround smuggles them via
+        // AdditionalData so they land on the wire. This test asserts the workaround
+        // produces a payload Kinde will accept.
+
+        [Fact]
+        public void CreateConnectionRequest_SamlEnums_LandOnWirePayload()
+        {
+            var saml = new CreateConnectionRequestOptionsOneOf2
+            {
+                SamlEntityId = "https://example.okta.com/saml/metadata",
+                SamlIdpMetadataUrl = "https://example.okta.com/sso/saml/metadata",
+                NameIdFormat = CreateConnectionRequestOptionsOneOf2.NameIdFormatEnum.EmailAddress,
+                ProtocolBinding = CreateConnectionRequestOptionsOneOf2.ProtocolBindingEnum.POST,
+                SignRequestAlgorithm = CreateConnectionRequestOptionsOneOf2.SignRequestAlgorithmEnum.SHA256,
+            };
+            var request = new CreateConnectionRequest(
+                name: "saml-okta",
+                strategy: CreateConnectionRequest.StrategyEnum.Samlokta,
+                options: new CreateConnectionRequestOptions(saml));
+
+            var kiota = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody>(request);
+            var member3 = kiota.Options.ConnectionsPostRequestBodyOptionsMember3;
+            Assert.NotNull(member3);
+
+            using var writer = new Microsoft.Kiota.Serialization.Json.JsonSerializationWriter();
+            writer.WriteObjectValue<Kinde.Api.Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember3>(null, member3);
+            using var stream = writer.GetSerializedContent();
+            using var reader = new System.IO.StreamReader(stream);
+            var json = reader.ReadToEnd();
+            _output.WriteLine("Wire body: " + json);
+
+            Assert.Contains("\"name_id_format\":\"Email address\"", json);
+            Assert.Contains("\"protocol_binding\":\"HTTP-POST\"", json);
+            Assert.Contains("\"sign_request_algorithm\":\"RSA-SHA256\"", json);
+            Assert.Contains("\"saml_entity_id\":\"https://example.okta.com/saml/metadata\"", json);
+        }
+
+        #endregion
+
         #region CreateConnectionRequest oneOf Options Tests
 
         [Fact]
@@ -552,6 +835,28 @@ namespace Kinde.Api.Test.Integration.Mappers
             Assert.Equal("contoso.com", kiota.Options.ConnectionsPostRequestBodyOptionsMember2.EntraIdDomain);
             Assert.True(kiota.Options.ConnectionsPostRequestBodyOptionsMember2.IsUseCommonEndpoint);
         }
+
+        [Fact]
+        public void CreateConnectionRequest_NullOptions_MapsToNull()
+        {
+            // Caller didn't provide Options. The mapper must NOT silently fabricate
+            // an empty Options object on the wire — that would send {} and could be
+            // misinterpreted by the API. Map should produce null on the destination.
+            var request = new CreateConnectionRequest(
+                name: "no-options",
+                displayName: "No options",
+                strategy: CreateConnectionRequest.StrategyEnum.Oauth2google);
+
+            var kiota = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody>(request);
+
+            Assert.NotNull(kiota);
+            Assert.Null(kiota.Options);
+        }
+
+        // Note: the `default:` branch in the mapper (unsupported ActualInstance type) is
+        // defensive future-proofing — CreateConnectionRequestOptions.ActualInstance has its
+        // own setter validation that already rejects unknown variants, so the branch is
+        // unreachable through the public API. No test for it.
 
         [Fact]
         public void CreateConnectionRequest_SamlOptions_MapsToMember3()

--- a/Kinde.Api.Test/Model/IdentityNullableDeserializationTests.cs
+++ b/Kinde.Api.Test/Model/IdentityNullableDeserializationTests.cs
@@ -4,18 +4,24 @@ using Xunit;
 
 namespace Kinde.Api.Test.Model
 {
-    // Regression: Social identities can return is_confirmed:null. Identity.IsConfirmed
-    // must accept null without throwing during deserialization.
+    // Contract: per the updated OpenAPI spec, Identity.is_confirmed is non-nullable
+    // (modelled in C# as `bool`). A missing field deserializes to the default (false);
+    // an explicit boolean roundtrips cleanly.
+    //
+    // History: the previous regression test asserted that is_confirmed could be null
+    // (Google social identities used to return null). That contract is no longer
+    // honoured by the spec. If the production API resumes returning null, this test
+    // will start failing with JsonSerializationException — at which point re-add the
+    // NULLABLE_BOOL_OVERRIDES entry in scripts/post-process-generated-code.py.
     public class IdentityNullableDeserializationTests
     {
         [Fact]
-        public void Deserialize_IsConfirmedNull_DoesNotThrow()
+        public void Deserialize_IsConfirmedMissing_DefaultsToFalse()
         {
             const string json = """
                 {
                   "id": "identity_019617f0cd72460a42192cf37b41084f",
                   "type": "google",
-                  "is_confirmed": null,
                   "name": "sally@example.com",
                   "email": "sally@example.com",
                   "is_primary": true
@@ -25,7 +31,27 @@ namespace Kinde.Api.Test.Model
             Identity identity = JsonConvert.DeserializeObject<Identity>(json)!;
 
             Assert.NotNull(identity);
-            Assert.Null(identity.IsConfirmed);
+            Assert.False(identity.IsConfirmed);
+        }
+
+        [Fact]
+        public void Deserialize_IsConfirmedTrue_RoundtripsCorrectly()
+        {
+            const string json = """
+                {
+                  "id": "identity_019617f0cd72460a42192cf37b41084f",
+                  "type": "email",
+                  "is_confirmed": true,
+                  "name": "sally@example.com",
+                  "email": "sally@example.com",
+                  "is_primary": true
+                }
+                """;
+
+            Identity identity = JsonConvert.DeserializeObject<Identity>(json)!;
+
+            Assert.NotNull(identity);
+            Assert.True(identity.IsConfirmed);
         }
     }
 }

--- a/Kinde.Api/Api/APIsApi.cs
+++ b/Kinde.Api/Api/APIsApi.cs
@@ -629,6 +629,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -651,7 +652,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -666,11 +667,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -830,6 +831,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/APIsApi.cs
+++ b/Kinde.Api/Api/APIsApi.cs
@@ -830,7 +830,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/ApplicationsApi.cs
+++ b/Kinde.Api/Api/ApplicationsApi.cs
@@ -577,6 +577,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -599,7 +600,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -614,11 +615,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -778,6 +779,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/ApplicationsApi.cs
+++ b/Kinde.Api/Api/ApplicationsApi.cs
@@ -778,7 +778,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/BillingAgreementsApi.cs
+++ b/Kinde.Api/Api/BillingAgreementsApi.cs
@@ -366,7 +366,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/BillingAgreementsApi.cs
+++ b/Kinde.Api/Api/BillingAgreementsApi.cs
@@ -165,6 +165,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -187,7 +188,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -202,11 +203,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -366,6 +367,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/BillingEntitlementsApi.cs
+++ b/Kinde.Api/Api/BillingEntitlementsApi.cs
@@ -125,6 +125,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -147,7 +148,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -162,11 +163,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -326,6 +327,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/BillingEntitlementsApi.cs
+++ b/Kinde.Api/Api/BillingEntitlementsApi.cs
@@ -326,7 +326,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/BillingMeterUsageApi.cs
+++ b/Kinde.Api/Api/BillingMeterUsageApi.cs
@@ -105,6 +105,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -127,7 +128,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -142,11 +143,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -306,6 +307,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/BillingMeterUsageApi.cs
+++ b/Kinde.Api/Api/BillingMeterUsageApi.cs
@@ -306,7 +306,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/BusinessApi.cs
+++ b/Kinde.Api/Api/BusinessApi.cs
@@ -145,6 +145,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -167,7 +168,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -182,11 +183,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -346,6 +347,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/BusinessApi.cs
+++ b/Kinde.Api/Api/BusinessApi.cs
@@ -346,7 +346,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/CallbacksApi.cs
+++ b/Kinde.Api/Api/CallbacksApi.cs
@@ -437,6 +437,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -459,7 +460,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -474,11 +475,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -638,6 +639,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/CallbacksApi.cs
+++ b/Kinde.Api/Api/CallbacksApi.cs
@@ -638,7 +638,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/ConnectedAppsApi.cs
+++ b/Kinde.Api/Api/ConnectedAppsApi.cs
@@ -406,7 +406,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/ConnectedAppsApi.cs
+++ b/Kinde.Api/Api/ConnectedAppsApi.cs
@@ -205,6 +205,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -227,7 +228,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -242,11 +243,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -406,6 +407,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/ConnectionsApi.cs
+++ b/Kinde.Api/Api/ConnectionsApi.cs
@@ -546,7 +546,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/ConnectionsApi.cs
+++ b/Kinde.Api/Api/ConnectionsApi.cs
@@ -345,6 +345,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -367,7 +368,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -382,11 +383,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -546,6 +547,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/EnvironmentVariablesApi.cs
+++ b/Kinde.Api/Api/EnvironmentVariablesApi.cs
@@ -281,6 +281,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -303,7 +304,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -318,11 +319,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -482,6 +483,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/EnvironmentVariablesApi.cs
+++ b/Kinde.Api/Api/EnvironmentVariablesApi.cs
@@ -482,7 +482,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/EnvironmentsApi.cs
+++ b/Kinde.Api/Api/EnvironmentsApi.cs
@@ -606,7 +606,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/EnvironmentsApi.cs
+++ b/Kinde.Api/Api/EnvironmentsApi.cs
@@ -405,6 +405,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -427,7 +428,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -442,11 +443,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -606,6 +607,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/FeatureFlagsApi.cs
+++ b/Kinde.Api/Api/FeatureFlagsApi.cs
@@ -213,6 +213,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -235,7 +236,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -250,11 +251,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -414,6 +415,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/FeatureFlagsApi.cs
+++ b/Kinde.Api/Api/FeatureFlagsApi.cs
@@ -414,7 +414,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/IdentitiesApi.cs
+++ b/Kinde.Api/Api/IdentitiesApi.cs
@@ -398,7 +398,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/IdentitiesApi.cs
+++ b/Kinde.Api/Api/IdentitiesApi.cs
@@ -197,6 +197,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -219,7 +220,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -234,11 +235,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -398,6 +399,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/IndustriesApi.cs
+++ b/Kinde.Api/Api/IndustriesApi.cs
@@ -302,7 +302,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/IndustriesApi.cs
+++ b/Kinde.Api/Api/IndustriesApi.cs
@@ -101,6 +101,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -123,7 +124,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -138,11 +139,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -302,6 +303,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/MFAApi.cs
+++ b/Kinde.Api/Api/MFAApi.cs
@@ -105,6 +105,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -127,7 +128,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -142,11 +143,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -306,6 +307,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/MFAApi.cs
+++ b/Kinde.Api/Api/MFAApi.cs
@@ -306,7 +306,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/OrganizationsApi.cs
+++ b/Kinde.Api/Api/OrganizationsApi.cs
@@ -1829,6 +1829,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -1851,7 +1852,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -1866,11 +1867,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -2034,6 +2035,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/OrganizationsApi.cs
+++ b/Kinde.Api/Api/OrganizationsApi.cs
@@ -2034,7 +2034,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/PermissionsApi.cs
+++ b/Kinde.Api/Api/PermissionsApi.cs
@@ -249,6 +249,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -271,7 +272,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -286,11 +287,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -450,6 +451,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/PermissionsApi.cs
+++ b/Kinde.Api/Api/PermissionsApi.cs
@@ -450,7 +450,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/PropertiesApi.cs
+++ b/Kinde.Api/Api/PropertiesApi.cs
@@ -454,7 +454,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/PropertiesApi.cs
+++ b/Kinde.Api/Api/PropertiesApi.cs
@@ -253,6 +253,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -275,7 +276,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -290,11 +291,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -454,6 +455,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/PropertyCategoriesApi.cs
+++ b/Kinde.Api/Api/PropertyCategoriesApi.cs
@@ -410,7 +410,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/PropertyCategoriesApi.cs
+++ b/Kinde.Api/Api/PropertyCategoriesApi.cs
@@ -209,6 +209,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -231,7 +232,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -246,11 +247,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -410,6 +411,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/RolesApi.cs
+++ b/Kinde.Api/Api/RolesApi.cs
@@ -786,7 +786,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/RolesApi.cs
+++ b/Kinde.Api/Api/RolesApi.cs
@@ -585,6 +585,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -607,7 +608,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -622,11 +623,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -786,6 +787,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/SearchApi.cs
+++ b/Kinde.Api/Api/SearchApi.cs
@@ -125,6 +125,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -147,7 +148,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -162,11 +163,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -326,6 +327,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/SearchApi.cs
+++ b/Kinde.Api/Api/SearchApi.cs
@@ -326,7 +326,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/SubscribersApi.cs
+++ b/Kinde.Api/Api/SubscribersApi.cs
@@ -410,7 +410,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/SubscribersApi.cs
+++ b/Kinde.Api/Api/SubscribersApi.cs
@@ -209,6 +209,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -231,7 +232,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -246,11 +247,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -410,6 +411,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/TimezonesApi.cs
+++ b/Kinde.Api/Api/TimezonesApi.cs
@@ -302,7 +302,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/TimezonesApi.cs
+++ b/Kinde.Api/Api/TimezonesApi.cs
@@ -101,6 +101,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -123,7 +124,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -138,11 +139,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -302,6 +303,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/UsersApi.cs
+++ b/Kinde.Api/Api/UsersApi.cs
@@ -1144,7 +1144,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/UsersApi.cs
+++ b/Kinde.Api/Api/UsersApi.cs
@@ -930,6 +930,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -961,7 +962,7 @@ namespace Kinde.Api.Api
                             ApiClientBuilder.RegisterDefaultDeserializer<Microsoft.Kiota.Serialization.Text.TextParseNodeFactory>();
                             ApiClientBuilder.RegisterDefaultDeserializer<Microsoft.Kiota.Serialization.Form.FormParseNodeFactory>();
                             
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -976,11 +977,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -1144,6 +1145,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Api/WebhooksApi.cs
+++ b/Kinde.Api/Api/WebhooksApi.cs
@@ -522,7 +522,13 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
-            this.Configuration = Kinde.Api.Client.GlobalConfiguration.Instance;
+            this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
+                Kinde.Api.Client.GlobalConfiguration.Instance,
+                new Kinde.Api.Client.Configuration
+                {
+                    BasePath = client.BasePath,
+                    AccessToken = client.AccessToken,
+                });
             this.ExceptionFactory = Kinde.Api.Client.Configuration.DefaultExceptionFactory;
         }
 

--- a/Kinde.Api/Api/WebhooksApi.cs
+++ b/Kinde.Api/Api/WebhooksApi.cs
@@ -321,6 +321,7 @@ namespace Kinde.Api.Api
         
         // ===== Kiota Infrastructure =====
         private KindeManagementClient _kiotaClient;
+        private Kinde.Api.Client.ApiClient _kindeApiClient;
         private HttpClient _kiotaHttpClient;
         private IMapper _kiotaMapper;
         private readonly object _kiotaLock = new object();
@@ -343,7 +344,7 @@ namespace Kinde.Api.Api
                     {
                         if (_kiotaClient == null)
                         {
-                            var tokenProvider = new KiotaTokenProvider(Configuration.AccessToken);
+                            var tokenProvider = new KiotaTokenProvider(() => _kindeApiClient?.AccessToken ?? Configuration.AccessToken);
                             var authProvider = new BaseBearerTokenAuthenticationProvider(tokenProvider);
                             _kiotaHttpClient ??= new HttpClient();
                             var adapter = new HttpClientRequestAdapter(authProvider, httpClient: _kiotaHttpClient);
@@ -358,11 +359,11 @@ namespace Kinde.Api.Api
 
         private class KiotaTokenProvider : IAccessTokenProvider
         {
-            private readonly string _token;
-            public KiotaTokenProvider(string token) => _token = token ?? string.Empty;
+            private readonly Func<string> _getToken;
+            public KiotaTokenProvider(Func<string> getToken) => _getToken = getToken ?? (() => string.Empty);
             public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
-            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default) 
-                => Task.FromResult(_token);
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> ctx = null, CancellationToken ct = default)
+                => Task.FromResult(_getToken() ?? string.Empty);
         }
         // ===== End Kiota Infrastructure =====
 private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
@@ -522,6 +523,7 @@ private Kinde.Api.Client.ExceptionFactory _exceptionFactory = (name, response) =
 
             this.Client = client;
             this.AsynchronousClient = client;
+            this._kindeApiClient = client;
             this.Configuration = Kinde.Api.Client.Configuration.MergeConfigurations(
                 Kinde.Api.Client.GlobalConfiguration.Instance,
                 new Kinde.Api.Client.Configuration

--- a/Kinde.Api/Client/ApiClient.cs
+++ b/Kinde.Api/Client/ApiClient.cs
@@ -98,13 +98,13 @@ namespace Kinde.Api.Client
 
         public async Task<T> Deserialize<T>(HttpResponseMessage response)
         {
-            var result = (T) await Deserialize(response, typeof(T), null).ConfigureAwait(false);
+            var result = (T)await Deserialize(response, typeof(T), null).ConfigureAwait(false);
             return result;
         }
 
         public async Task<T> Deserialize<T>(HttpResponseMessage response, string rawContent)
         {
-            var result = (T) await Deserialize(response, typeof(T), rawContent).ConfigureAwait(false);
+            var result = (T)await Deserialize(response, typeof(T), rawContent).ConfigureAwait(false);
             return result;
         }
 
@@ -225,6 +225,21 @@ namespace Kinde.Api.Client
         private readonly bool _disposeClient;
 
         /// <summary>
+        /// The base URL the client was constructed with. Used by generated API classes
+        /// to propagate the caller's domain into Configuration when this client is passed
+        /// to an XApi(ApiClient) constructor.
+        /// </summary>
+        public virtual string BasePath => _baseUrl;
+
+        /// <summary>
+        /// The current bearer access token associated with this client, or null if none.
+        /// Derived clients (such as KindeClient) override this to expose their OAuth token
+        /// so generated API classes can authenticate Kiota calls without the caller having
+        /// to construct a Configuration manually.
+        /// </summary>
+        public virtual string AccessToken => null;
+
+        /// <summary>
         /// Specifies the settings on a <see cref="JsonSerializer" /> object.
         /// These settings can be adjusted to accommodate custom serialization rules.
         /// </summary>
@@ -306,7 +321,8 @@ namespace Kinde.Api.Client
         /// </summary>
         public void Dispose()
         {
-            if(_disposeClient) {
+            if (_disposeClient)
+            {
                 _httpClient.Dispose();
             }
         }
@@ -445,7 +461,7 @@ namespace Kinde.Api.Client
 
         private async Task<ApiResponse<T>> ToApiResponse<T>(HttpResponseMessage response, object responseData, Uri uri, string rawContent = null)
         {
-            T result = (T) responseData;
+            T result = (T)responseData;
             string content = rawContent ?? await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>(), result, content)
@@ -474,13 +490,14 @@ namespace Kinde.Api.Client
 
             if (_httpClientHandler != null && response != null)
             {
-                try {
+                try
+                {
                     foreach (Cookie cookie in _httpClientHandler.CookieContainer.GetCookies(uri))
                     {
                         transformed.Cookies.Add(cookie);
                     }
                 }
-                catch (PlatformNotSupportedException) {}
+                catch (PlatformNotSupportedException) { }
             }
 
             return transformed;
@@ -511,13 +528,13 @@ namespace Kinde.Api.Client
 
                 if (configuration.Proxy != null)
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Configuration `Proxy` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    if (_httpClientHandler == null) throw new InvalidOperationException("Configuration `Proxy` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
                     _httpClientHandler.Proxy = configuration.Proxy;
                 }
 
                 if (configuration.ClientCertificates != null)
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    if (_httpClientHandler == null) throw new InvalidOperationException("Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
                     _httpClientHandler.ClientCertificates.AddRange(configuration.ClientCertificates);
                 }
 
@@ -525,7 +542,7 @@ namespace Kinde.Api.Client
 
                 if (cookieContainer != null)
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    if (_httpClientHandler == null) throw new InvalidOperationException("Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
                     foreach (var cookie in cookieContainer)
                     {
                         _httpClientHandler.CookieContainer.Add(cookie);
@@ -561,18 +578,18 @@ namespace Kinde.Api.Client
 
                 // Buffer the response content before deserialization so it can be read multiple times
                 string rawContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                
+
                 object responseData = await deserializer.Deserialize<T>(response, rawContent).ConfigureAwait(false);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(Kinde.Api.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
                 {
                     // For oneOf/anyOf types, we need to pass the raw content
-                    responseData = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { rawContent });
+                    responseData = (T)typeof(T).GetMethod("FromJson").Invoke(null, new object[] { rawContent });
                 }
                 else if (typeof(T).Name == "Stream") // for binary response
                 {
-                    responseData = (T) (object) new MemoryStream(System.Text.Encoding.UTF8.GetBytes(rawContent));
+                    responseData = (T)(object)new MemoryStream(System.Text.Encoding.UTF8.GetBytes(rawContent));
                 }
 
                 InterceptResponse(req, response);

--- a/Kinde.Api/KindeClient.cs
+++ b/Kinde.Api/KindeClient.cs
@@ -36,7 +36,14 @@ namespace Kinde.Api.Client
         public OauthToken Token => AuthorizationFlow?.Token;
 
         /// <summary>
-        /// To check user authenticated or not	
+        /// Exposes the OAuth access token to generated API classes so they can populate
+        /// Configuration.AccessToken when constructed via XApi(ApiClient client).
+        /// Without this, every Kiota-backed call from such an API class is unauthenticated.
+        /// </summary>
+        public override string AccessToken => Token?.AccessToken;
+
+        /// <summary>
+        /// To check user authenticated or not
         /// </summary>
         public bool IsAuthenticated => Token != null && !Token.IsExpired;
 

--- a/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
+++ b/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using AutoMapper;
 using Kinde.Api.Model;
 using KiotaModels = Kinde.Api.Kiota.Management.Models;
@@ -71,7 +75,31 @@ namespace Kinde.Api.Mappers
          
             CreateMap<CreateConnectionRequestOptionsOneOf,  Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember1>().ReverseMap();
             CreateMap<CreateConnectionRequestOptionsOneOf1, Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember2>().ReverseMap();
-            CreateMap<CreateConnectionRequestOptionsOneOf2, Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember3>().ReverseMap();
+            // SAML variant: Kiota's optionsMember3 is missing name_id_format, protocol_binding,
+            // and sign_request_algorithm (Kiota schema out-of-sync with OpenAPI spec). Smuggle
+            // them through AdditionalData so Kiota writes them on the wire payload anyway.
+            CreateMap<CreateConnectionRequestOptionsOneOf2, Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember3>()
+                .AfterMap((src, dst) =>
+                {
+                    dst.AdditionalData ??= new Dictionary<string, object>();
+                    if (src.NameIdFormat is { } nf)            dst.AdditionalData["name_id_format"]        = GetEnumMemberValue(nf);
+                    if (src.ProtocolBinding is { } pb)         dst.AdditionalData["protocol_binding"]      = GetEnumMemberValue(pb);
+                    if (src.SignRequestAlgorithm is { } algo)  dst.AdditionalData["sign_request_algorithm"] = GetEnumMemberValue(algo);
+                })
+                .ReverseMap()
+                .AfterMap((src, dst) =>
+                {
+                    if (src.AdditionalData is null) return;
+                    if (src.AdditionalData.TryGetValue("name_id_format", out var nf) && nf is string nfs
+                        && TryParseEnumMember<CreateConnectionRequestOptionsOneOf2.NameIdFormatEnum>(nfs, out var nfv))
+                        dst.NameIdFormat = nfv;
+                    if (src.AdditionalData.TryGetValue("protocol_binding", out var pb) && pb is string pbs
+                        && TryParseEnumMember<CreateConnectionRequestOptionsOneOf2.ProtocolBindingEnum>(pbs, out var pbv))
+                        dst.ProtocolBinding = pbv;
+                    if (src.AdditionalData.TryGetValue("sign_request_algorithm", out var sa) && sa is string sas
+                        && TryParseEnumMember<CreateConnectionRequestOptionsOneOf2.SignRequestAlgorithmEnum>(sas, out var sav))
+                        dst.SignRequestAlgorithm = sav;
+                });
 
             CreateMap<CreateConnectionRequestOptions, Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody.ConnectionsPostRequestBody_options>()
                 .ConvertUsing((src, _, ctx) =>
@@ -396,6 +424,34 @@ namespace Kinde.Api.Mappers
             
             // Additional User mappings (Users_response_users to OpenAPI User model)
             CreateMap<KiotaModels.Users_response_users, User>().ReverseMap();
+        }
+
+        // Returns the [EnumMember(Value = "…")] string for an enum value, or its .NET name
+        // as a fallback. Used by the SAML CreateConnection workaround to write enum values
+        // through Kiota's AdditionalData bag when the destination model is missing the field.
+        private static string GetEnumMemberValue(Enum value)
+        {
+            var member = value.GetType().GetMember(value.ToString()).FirstOrDefault();
+            var attr = member?.GetCustomAttribute<System.Runtime.Serialization.EnumMemberAttribute>();
+            return attr?.Value ?? value.ToString();
+        }
+
+        // Reverse of GetEnumMemberValue: find the enum member whose [EnumMember(Value = "…")]
+        // matches the given string. Used on the reverse-map path.
+        private static bool TryParseEnumMember<TEnum>(string value, out TEnum result) where TEnum : struct, Enum
+        {
+            foreach (var name in Enum.GetNames(typeof(TEnum)))
+            {
+                var member = typeof(TEnum).GetMember(name).FirstOrDefault();
+                var attr = member?.GetCustomAttribute<System.Runtime.Serialization.EnumMemberAttribute>();
+                if (attr?.Value == value)
+                {
+                    result = (TEnum)Enum.Parse(typeof(TEnum), name);
+                    return true;
+                }
+            }
+            result = default;
+            return false;
         }
     }
 }

--- a/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
+++ b/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
@@ -122,8 +122,105 @@ namespace Kinde.Api.Mappers
                 });
 
             CreateMap<CreateConnectionRequest, Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody>();
-            CreateMap<ReplaceConnectionRequest, Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody>().ReverseMap();
-            CreateMap<UpdateConnectionRequest, Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody>().ReverseMap();
+
+            // === ReplaceConnectionRequest (PUT) — same oneOf-Options bug as Create ===
+            // Variants: social (CreateConnectionRequestOptionsOneOf, shared with Create),
+            // Entra (ReplaceConnectionRequestOptionsOneOf), SAML (ReplaceConnectionRequestOptionsOneOf1).
+            CreateMap<CreateConnectionRequestOptionsOneOf,   Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody_optionsMember1>().ReverseMap();
+            CreateMap<ReplaceConnectionRequestOptionsOneOf,  Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody_optionsMember2>().ReverseMap();
+            // SAML: same Kiota schema gap (name_id_format, protocol_binding, sign_request_algorithm missing on Member3).
+            CreateMap<ReplaceConnectionRequestOptionsOneOf1, Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody_optionsMember3>()
+                .AfterMap((src, dst) =>
+                {
+                    dst.AdditionalData ??= new Dictionary<string, object>();
+                    if (src.NameIdFormat is { } nf)            dst.AdditionalData["name_id_format"]        = GetEnumMemberValue(nf);
+                    if (src.ProtocolBinding is { } pb)         dst.AdditionalData["protocol_binding"]      = GetEnumMemberValue(pb);
+                    if (src.SignRequestAlgorithm is { } algo)  dst.AdditionalData["sign_request_algorithm"] = GetEnumMemberValue(algo);
+                })
+                .ReverseMap()
+                .AfterMap((src, dst) =>
+                {
+                    if (src.AdditionalData is null) return;
+                    if (src.AdditionalData.TryGetValue("name_id_format", out var nf) && nf is string nfs
+                        && TryParseEnumMember<ReplaceConnectionRequestOptionsOneOf1.NameIdFormatEnum>(nfs, out var nfv))
+                        dst.NameIdFormat = nfv;
+                    if (src.AdditionalData.TryGetValue("protocol_binding", out var pb) && pb is string pbs
+                        && TryParseEnumMember<ReplaceConnectionRequestOptionsOneOf1.ProtocolBindingEnum>(pbs, out var pbv))
+                        dst.ProtocolBinding = pbv;
+                    if (src.AdditionalData.TryGetValue("sign_request_algorithm", out var sa) && sa is string sas
+                        && TryParseEnumMember<ReplaceConnectionRequestOptionsOneOf1.SignRequestAlgorithmEnum>(sas, out var sav))
+                        dst.SignRequestAlgorithm = sav;
+                });
+
+            CreateMap<ReplaceConnectionRequestOptions, Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody.WithConnection_PutRequestBody_options>()
+                .ConvertUsing((src, _, ctx) =>
+                {
+                    if (src?.ActualInstance is null) return null;
+
+                    var dst = new Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody.WithConnection_PutRequestBody_options();
+                    switch (src.ActualInstance)
+                    {
+                        case CreateConnectionRequestOptionsOneOf   s: dst.WithConnectionPutRequestBodyOptionsMember1 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody_optionsMember1>(s); break;
+                        case ReplaceConnectionRequestOptionsOneOf  s: dst.WithConnectionPutRequestBodyOptionsMember2 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody_optionsMember2>(s); break;
+                        case ReplaceConnectionRequestOptionsOneOf1 s: dst.WithConnectionPutRequestBodyOptionsMember3 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody_optionsMember3>(s); break;
+                        default:
+                            throw new ArgumentException(
+                                $"Unsupported ReplaceConnectionRequestOptions variant: {src.ActualInstance.GetType().FullName}. " +
+                                "Expected CreateConnectionRequestOptionsOneOf, ReplaceConnectionRequestOptionsOneOf, or ReplaceConnectionRequestOptionsOneOf1.",
+                                nameof(src));
+                    }
+                    return dst;
+                });
+
+            CreateMap<ReplaceConnectionRequest, Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody>();
+
+            // === UpdateConnectionRequest (PATCH) — same oneOf-Options bug ===
+            CreateMap<CreateConnectionRequestOptionsOneOf,  Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody_optionsMember1>().ReverseMap();
+            CreateMap<UpdateConnectionRequestOptionsOneOf,  Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody_optionsMember2>().ReverseMap();
+            CreateMap<UpdateConnectionRequestOptionsOneOf1, Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody_optionsMember3>()
+                .AfterMap((src, dst) =>
+                {
+                    dst.AdditionalData ??= new Dictionary<string, object>();
+                    if (src.NameIdFormat is { } nf)            dst.AdditionalData["name_id_format"]        = GetEnumMemberValue(nf);
+                    if (src.ProtocolBinding is { } pb)         dst.AdditionalData["protocol_binding"]      = GetEnumMemberValue(pb);
+                    if (src.SignRequestAlgorithm is { } algo)  dst.AdditionalData["sign_request_algorithm"] = GetEnumMemberValue(algo);
+                })
+                .ReverseMap()
+                .AfterMap((src, dst) =>
+                {
+                    if (src.AdditionalData is null) return;
+                    if (src.AdditionalData.TryGetValue("name_id_format", out var nf) && nf is string nfs
+                        && TryParseEnumMember<UpdateConnectionRequestOptionsOneOf1.NameIdFormatEnum>(nfs, out var nfv))
+                        dst.NameIdFormat = nfv;
+                    if (src.AdditionalData.TryGetValue("protocol_binding", out var pb) && pb is string pbs
+                        && TryParseEnumMember<UpdateConnectionRequestOptionsOneOf1.ProtocolBindingEnum>(pbs, out var pbv))
+                        dst.ProtocolBinding = pbv;
+                    if (src.AdditionalData.TryGetValue("sign_request_algorithm", out var sa) && sa is string sas
+                        && TryParseEnumMember<UpdateConnectionRequestOptionsOneOf1.SignRequestAlgorithmEnum>(sas, out var sav))
+                        dst.SignRequestAlgorithm = sav;
+                });
+
+            CreateMap<UpdateConnectionRequestOptions, Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody.WithConnection_PatchRequestBody_options>()
+                .ConvertUsing((src, _, ctx) =>
+                {
+                    if (src?.ActualInstance is null) return null;
+
+                    var dst = new Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody.WithConnection_PatchRequestBody_options();
+                    switch (src.ActualInstance)
+                    {
+                        case CreateConnectionRequestOptionsOneOf  s: dst.WithConnectionPatchRequestBodyOptionsMember1 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody_optionsMember1>(s); break;
+                        case UpdateConnectionRequestOptionsOneOf  s: dst.WithConnectionPatchRequestBodyOptionsMember2 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody_optionsMember2>(s); break;
+                        case UpdateConnectionRequestOptionsOneOf1 s: dst.WithConnectionPatchRequestBodyOptionsMember3 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody_optionsMember3>(s); break;
+                        default:
+                            throw new ArgumentException(
+                                $"Unsupported UpdateConnectionRequestOptions variant: {src.ActualInstance.GetType().FullName}. " +
+                                "Expected CreateConnectionRequestOptionsOneOf, UpdateConnectionRequestOptionsOneOf, or UpdateConnectionRequestOptionsOneOf1.",
+                                nameof(src));
+                    }
+                    return dst;
+                });
+
+            CreateMap<UpdateConnectionRequest, Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody>();
             
             // Environment Variable
             CreateMap<KiotaModels.Create_environment_variable_response, CreateEnvironmentVariableResponse>().ReverseMap();

--- a/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
+++ b/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
@@ -68,7 +68,25 @@ namespace Kinde.Api.Mappers
             // Connection
             CreateMap<KiotaModels.Create_connection_response, CreateConnectionResponse>().ReverseMap();
             CreateMap<KiotaModels.Create_connection_response_connection, CreateConnectionResponseConnection>().ReverseMap();
-            CreateMap<CreateConnectionRequest, Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody>().ReverseMap();
+         
+            CreateMap<CreateConnectionRequestOptionsOneOf,  Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember1>().ReverseMap();
+            CreateMap<CreateConnectionRequestOptionsOneOf1, Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember2>().ReverseMap();
+            CreateMap<CreateConnectionRequestOptionsOneOf2, Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember3>().ReverseMap();
+
+            CreateMap<CreateConnectionRequestOptions, Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody.ConnectionsPostRequestBody_options>()
+                .ConvertUsing((src, _, ctx) =>
+                {
+                    var dst = new Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody.ConnectionsPostRequestBody_options();
+                    switch (src?.ActualInstance)
+                    {
+                        case CreateConnectionRequestOptionsOneOf  s: dst.ConnectionsPostRequestBodyOptionsMember1 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember1>(s); break;
+                        case CreateConnectionRequestOptionsOneOf1 s: dst.ConnectionsPostRequestBodyOptionsMember2 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember2>(s); break;
+                        case CreateConnectionRequestOptionsOneOf2 s: dst.ConnectionsPostRequestBodyOptionsMember3 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember3>(s); break;
+                    }
+                    return dst;
+                });
+
+            CreateMap<CreateConnectionRequest, Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody>();
             CreateMap<ReplaceConnectionRequest, Kiota.Management.Api.V1.Connections.Item.WithConnection_PutRequestBody>().ReverseMap();
             CreateMap<UpdateConnectionRequest, Kiota.Management.Api.V1.Connections.Item.WithConnection_PatchRequestBody>().ReverseMap();
             

--- a/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
+++ b/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
@@ -76,12 +76,19 @@ namespace Kinde.Api.Mappers
             CreateMap<CreateConnectionRequestOptions, Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody.ConnectionsPostRequestBody_options>()
                 .ConvertUsing((src, _, ctx) =>
                 {
+                    if (src?.ActualInstance is null) return null;
+
                     var dst = new Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody.ConnectionsPostRequestBody_options();
-                    switch (src?.ActualInstance)
+                    switch (src.ActualInstance)
                     {
                         case CreateConnectionRequestOptionsOneOf  s: dst.ConnectionsPostRequestBodyOptionsMember1 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember1>(s); break;
                         case CreateConnectionRequestOptionsOneOf1 s: dst.ConnectionsPostRequestBodyOptionsMember2 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember2>(s); break;
                         case CreateConnectionRequestOptionsOneOf2 s: dst.ConnectionsPostRequestBodyOptionsMember3 = ctx.Mapper.Map<Kiota.Management.Api.V1.Connections.ConnectionsPostRequestBody_optionsMember3>(s); break;
+                        default:
+                            throw new ArgumentException(
+                                $"Unsupported CreateConnectionRequestOptions variant: {src.ActualInstance.GetType().FullName}. " +
+                                "Expected CreateConnectionRequestOptionsOneOf, OneOf1, or OneOf2.",
+                                nameof(src));
                     }
                     return dst;
                 });

--- a/Kinde.Api/Model/Identity.cs
+++ b/Kinde.Api/Model/Identity.cs
@@ -43,7 +43,7 @@ namespace Kinde.Api.Model
         /// <param name="name">The value of the identity.</param>
         /// <param name="email">The associated email of the identity.</param>
         /// <param name="isPrimary">Whether the identity is the primary identity for the user.</param>
-        public Identity(string id = default(string), string type = default(string), bool? isConfirmed = default(bool?), string createdOn = default(string), string lastLoginOn = default(string), int totalLogins = default(int), string name = default(string), string email = default(string), bool? isPrimary = default(bool?))
+        public Identity(string id = default(string), string type = default(string), bool isConfirmed = default(bool), string createdOn = default(string), string lastLoginOn = default(string), int totalLogins = default(int), string name = default(string), string email = default(string), bool? isPrimary = default(bool?))
         {
             this.Id = id;
             this.Type = type;
@@ -78,7 +78,7 @@ namespace Kinde.Api.Model
         /// <value>Whether the identity is confirmed</value>
         /// <example>true</example>
         [DataMember(Name = "is_confirmed", EmitDefaultValue = true)]
-        public bool? IsConfirmed { get; set; }
+        public bool IsConfirmed { get; set; }
 
         /// <summary>
         /// Date of user creation in ISO 8601 format

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -11476,7 +11476,6 @@ components:
           type: boolean
           description: Whether the identity is confirmed
           example: true
-          nullable: true
         created_on:
           type: string
           description: Date of user creation in ISO 8601 format


### PR DESCRIPTION
Add mappings to handle polymorphic CreateConnectionRequest options and unit tests for each oneOf variant. Introduces CreateMap mappings for the three option member types and a custom ConvertUsing for CreateConnectionRequestOptions to populate the correct ConnectionsPostRequestBody options member. Adds integration tests verifying mapping of social (member1), Entra (member2), and SAML (member3) option payloads to the Kiota request body.

# Explain your changes

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
