### PR TITLE
fix: add mappings and tests for property and arrays

### DIFF
--- a/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
+++ b/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
@@ -1058,6 +1058,20 @@ private static object FindReachableInstance(object root, Type target, int maxDep
             Assert.Null(dst.Value.String);
         }
 
+        [Fact]
+        public void UpdateApplicationsPropertyRequestValue_ReverseMap_PreservesEmptyString()
+        {
+            var kiotaValue = new Kinde.Api.Kiota.Management.Api.V1.Applications.Item.Properties.Item.WithProperty_keyPutRequestBody.WithProperty_keyPutRequestBody_value
+            {
+                String = string.Empty,
+            };
+
+            var dst = _mapper.Map<UpdateApplicationsPropertyRequestValue>(kiotaValue);
+
+            Assert.NotNull(dst);
+            Assert.Equal(string.Empty, dst.ActualInstance);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
+++ b/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
@@ -977,6 +977,87 @@ private static object FindReachableInstance(object root, Type target, int maxDep
             Assert.Contains("\"is_recovery_codes_enabled\":true", json);
         }
 
+        [Fact]
+        public void CreateUserRequest_WithEmailIdentity_MapsDetailsThrough()
+        {
+            var src = new CreateUserRequest(
+                profile: new CreateUserRequestProfile(givenName: "Jane", familyName: "Doe"),
+                identities: new List<CreateUserRequestIdentitiesInner>
+                {
+                    new CreateUserRequestIdentitiesInner(
+                        type: CreateUserRequestIdentitiesInner.TypeEnum.Email,
+                        details: new CreateUserRequestIdentitiesInnerDetails(email: "jane@example.com"))
+                });
+
+            var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.User.UserPostRequestBody>(src);
+
+            Assert.NotNull(dst.Identities);
+            Assert.Single(dst.Identities);
+            Assert.Equal("jane@example.com", dst.Identities[0].Details!.Email);
+        }
+
+        [Fact]
+        public void UpdateOrganizationUsersRequest_WithUsersInner_MapsArrayItems()
+        {
+            var src = new UpdateOrganizationUsersRequest(users: new List<UpdateOrganizationUsersRequestUsersInner>
+            {
+                new UpdateOrganizationUsersRequestUsersInner(
+                    id: "kp_user1",
+                    operation: "add",
+                    roles: new List<string> { "role_admin" },
+                    permissions: new List<string> { "read:users" }),
+            });
+
+            var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Organizations.Item.Users.UsersPatchRequestBody>(src);
+
+            Assert.NotNull(dst.Users);
+            Assert.Single(dst.Users);
+            Assert.Equal("kp_user1", dst.Users[0].Id);
+            Assert.Equal("add", dst.Users[0].Operation);
+            Assert.Equal(new[] { "role_admin" }, dst.Users[0].Roles);
+            Assert.Equal(new[] { "read:users" }, dst.Users[0].Permissions);
+        }
+
+        [Fact]
+        public void UpdateAPIApplicationsRequest_WithApplicationsInner_MapsArrayItems()
+        {
+            var src = new UpdateAPIApplicationsRequest(applications: new List<UpdateAPIApplicationsRequestApplicationsInner>
+            {
+                new UpdateAPIApplicationsRequestApplicationsInner(id: "app_abc", operation: "add"),
+            });
+
+            var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Apis.Item.Applications.ApplicationsPatchRequestBody>(src);
+
+            Assert.NotNull(dst.Applications);
+            Assert.Single(dst.Applications);
+            Assert.Equal("app_abc", dst.Applications[0].Id);
+            Assert.Equal("add", dst.Applications[0].Operation);
+        }
+
+        [Fact]
+        public void UpdateApplicationsPropertyRequest_StringValue_MapsToOneOfString()
+        {
+            var src = new UpdateApplicationsPropertyRequest(value: new UpdateApplicationsPropertyRequestValue("custom-value"));
+
+            var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Applications.Item.Properties.Item.WithProperty_keyPutRequestBody>(src);
+
+            Assert.NotNull(dst.Value);
+            Assert.Equal("custom-value", dst.Value.String);
+            Assert.Null(dst.Value.Boolean);
+        }
+
+        [Fact]
+        public void UpdateApplicationsPropertyRequest_BooleanValue_MapsToOneOfBoolean()
+        {
+            var src = new UpdateApplicationsPropertyRequest(value: new UpdateApplicationsPropertyRequestValue(true));
+
+            var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Applications.Item.Properties.Item.WithProperty_keyPutRequestBody>(src);
+
+            Assert.NotNull(dst.Value);
+            Assert.True(dst.Value.Boolean);
+            Assert.Null(dst.Value.String);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
+++ b/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
@@ -434,7 +434,7 @@ namespace Kinde.Api.Mappers
                 {
                     if (src is null) return null;
                     if (src.Boolean.HasValue) return new UpdateApplicationsPropertyRequestValue(src.Boolean.Value);
-                    if (!string.IsNullOrEmpty(src.String)) return new UpdateApplicationsPropertyRequestValue(src.String);
+                    if (src.String is not null) return new UpdateApplicationsPropertyRequestValue(src.String);
                     return null;
                 });
 

--- a/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
+++ b/Kinde.Api/Mappers/ManagementApiMapperProfile.cs
@@ -411,6 +411,33 @@ namespace Kinde.Api.Mappers
             CreateMap<CreateApplicationRequest, Kiota.Management.Api.V1.Applications.ApplicationsPostRequestBody>().ReverseMap();
             CreateMap<UpdateApplicationRequest, Kiota.Management.Api.V1.Applications.Item.Application_PatchRequestBody>().ReverseMap();
             CreateMap<UpdateApplicationTokensRequest, Kiota.Management.Api.V1.Applications.Item.Tokens.TokensPatchRequestBody>().ReverseMap();
+            CreateMap<UpdateApplicationsPropertyRequestValue, Kiota.Management.Api.V1.Applications.Item.Properties.Item.WithProperty_keyPutRequestBody.WithProperty_keyPutRequestBody_value>()
+                .ConvertUsing((src, _, _) =>
+                {
+                    if (src?.ActualInstance is null) return null;
+
+                    var dst = new Kiota.Management.Api.V1.Applications.Item.Properties.Item.WithProperty_keyPutRequestBody.WithProperty_keyPutRequestBody_value();
+                    switch (src.ActualInstance)
+                    {
+                        case bool b: dst.Boolean = b; break;
+                        case string s: dst.String = s; break;
+                        default:
+                            throw new ArgumentException(
+                                $"Unsupported UpdateApplicationsPropertyRequestValue variant: {src.ActualInstance.GetType().FullName}. Expected bool or string.",
+                                nameof(src));
+                    }
+                    return dst;
+                });
+
+            CreateMap<Kiota.Management.Api.V1.Applications.Item.Properties.Item.WithProperty_keyPutRequestBody.WithProperty_keyPutRequestBody_value, UpdateApplicationsPropertyRequestValue>()
+                .ConvertUsing((src, _, _) =>
+                {
+                    if (src is null) return null;
+                    if (src.Boolean.HasValue) return new UpdateApplicationsPropertyRequestValue(src.Boolean.Value);
+                    if (!string.IsNullOrEmpty(src.String)) return new UpdateApplicationsPropertyRequestValue(src.String);
+                    return null;
+                });
+
             CreateMap<UpdateApplicationsPropertyRequest, Kiota.Management.Api.V1.Applications.Item.Properties.Item.WithProperty_keyPutRequestBody>().ReverseMap();
 
             CreateMap<CreateBillingAgreementRequest, Kiota.Management.Api.V1.Billing.Agreements.AgreementsPostRequestBody>().ReverseMap();
@@ -445,6 +472,7 @@ namespace Kinde.Api.Mappers
             CreateMap<CreateUserRequest, Kiota.Management.Api.V1.User.UserPostRequestBody>().ReverseMap();
             CreateMap<CreateUserRequestProfile, Kiota.Management.Api.V1.User.UserPostRequestBody_profile>().ReverseMap();
             CreateMap<CreateUserRequestIdentitiesInner, Kiota.Management.Api.V1.User.UserPostRequestBody_identities>().ReverseMap();
+            CreateMap<CreateUserRequestIdentitiesInnerDetails, Kiota.Management.Api.V1.User.UserPostRequestBody_identities_details>().ReverseMap();
             CreateMap<UpdateUserRequest, Kiota.Management.Api.V1.User.UserPatchRequestBody>().ReverseMap();
 
             CreateMap<CreateOrganizationRequest, Kiota.Management.Api.V1.Organization.OrganizationPostRequestBody>()
@@ -461,6 +489,7 @@ namespace Kinde.Api.Mappers
 
             CreateMap<AddAPIsRequest, Kiota.Management.Api.V1.Apis.ApisPostRequestBody>().ReverseMap();
             CreateMap<UpdateAPIApplicationsRequest, Kiota.Management.Api.V1.Apis.Item.Applications.ApplicationsPatchRequestBody>().ReverseMap();
+            CreateMap<UpdateAPIApplicationsRequestApplicationsInner, Kiota.Management.Api.V1.Apis.Item.Applications.ApplicationsPatchRequestBody_applications>().ReverseMap();
             CreateMap<UpdateAPIScopeRequest, Kiota.Management.Api.V1.Apis.Item.Scopes.Item.WithScope_PatchRequestBody>().ReverseMap();
 
             CreateMap<UpdateOrganizationRequest, Kiota.Management.Api.V1.Organization.Item.WithOrg_codePatchRequestBody>().ReverseMap();
@@ -468,6 +497,7 @@ namespace Kinde.Api.Mappers
             CreateMap<UpdateOrganizationPropertiesRequest, Kiota.Management.Api.V1.Organizations.Item.Properties.PropertiesPatchRequestBody>().ReverseMap();
             CreateMap<UpdateOrganizationSessionsRequest, Kiota.Management.Api.V1.Organizations.Item.Sessions.SessionsPatchRequestBody>().ReverseMap();
             CreateMap<UpdateOrganizationUsersRequest, Kiota.Management.Api.V1.Organizations.Item.Users.UsersPatchRequestBody>().ReverseMap();
+            CreateMap<UpdateOrganizationUsersRequestUsersInner, Kiota.Management.Api.V1.Organizations.Item.Users.UsersPatchRequestBody_users>().ReverseMap();
 
             CreateMap<CreateUserIdentityRequest, Kiota.Management.Api.V1.Users.Item.Identities.IdentitiesPostRequestBody>().ReverseMap();
             CreateMap<SetUserPasswordRequest, Kiota.Management.Api.V1.Users.Item.Password.PasswordPutRequestBody>().ReverseMap();


### PR DESCRIPTION
Add custom AutoMapper conversions and missing type maps to handle Kiota-generated types and array/item inner types, and add unit tests verifying the mappings. ManagementApiMapperProfile: convert UpdateApplicationsPropertyRequestValue to/from the Kiota oneOf value type (handle bool and string, throw on unsupported types), and add maps for CreateUserRequestIdentitiesInnerDetails, UpdateAPIApplicationsRequestApplicationsInner, and UpdateOrganizationUsersRequestUsersInner. AutoMapperTests: add tests to assert mapping of email identity details, organization users array items, API applications array items, and application property values mapping for both string and boolean variants.

# Explain your changes

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
