### PR TITLE
Honor Kiota backing-store semantics in AutoMapper

### DIFF
--- a/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
+++ b/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
@@ -937,24 +937,93 @@ private static object FindReachableInstance(object root, Type target, int maxDep
             Assert.Equal(flag, roundTrip.IsRecoveryCodesEnabled);
         }
 
+        /// <summary>
+        /// Serializes a Kiota model the way the request adapter does, through the backing
+        /// store proxy. A plain JsonSerializationWriter drops nulls, so it hides the
+        /// difference between "never assigned" and "assigned null" -- which is exactly the
+        /// difference that decides what goes on the wire.
+        /// </summary>
+        private static string SerializeAsSent<T>(T model) where T : Microsoft.Kiota.Abstractions.Serialization.IParsable
+        {
+            var factory = new Microsoft.Kiota.Abstractions.Store.BackingStoreSerializationWriterProxyFactory(
+                new Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory());
+            using var writer = factory.GetSerializationWriter("application/json");
+            writer.WriteObjectValue(null, model);
+            using var stream = writer.GetSerializedContent();
+            using var reader = new System.IO.StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+
         [Fact]
-        public void ReplaceMFARequest_UnsetRecoveryCodes_StaysNullOnWire()
+        public void ReplaceMFARequest_UnsetRecoveryCodes_SendsSchemaDefaultNotNull()
         {
             var src = new ReplaceMFARequest(
                 policy: ReplaceMFARequest.PolicyEnum.Required,
                 enabledFactors: new List<ReplaceMFARequest.EnabledFactorsEnum> { ReplaceMFARequest.EnabledFactorsEnum.Email });
 
             var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Mfa.MfaPutRequestBody>(src);
+            var json = SerializeAsSent(dst);
 
-            Assert.Null(dst.IsRecoveryCodesEnabled);
+            _output.WriteLine("Wire body: " + json);
 
-            using var serWriter = new Microsoft.Kiota.Serialization.Json.JsonSerializationWriter();
-            serWriter.WriteObjectValue<Kinde.Api.Kiota.Management.Api.V1.Mfa.MfaPutRequestBody>(null, dst);
-            using var stream = serWriter.GetSerializedContent();
-            using var reader = new System.IO.StreamReader(stream);
-            var json = reader.ReadToEnd();
+            // The caller left the flag unset, so the Kiota model keeps the schema default
+            // (true) rather than having it overwritten with an explicit null. Sending
+            // "is_recovery_codes_enabled": null would be rejected by the API.
+            Assert.DoesNotContain("\"is_recovery_codes_enabled\":null", json);
+            Assert.Contains("\"is_recovery_codes_enabled\":true", json);
+        }
 
-            Assert.DoesNotContain("\"is_recovery_codes_enabled\"", json);
+        [Fact]
+        public void ReplaceMFARequest_ExplicitFalseRecoveryCodes_SurvivesToTheWire()
+        {
+            var src = new ReplaceMFARequest(
+                policy: ReplaceMFARequest.PolicyEnum.Required,
+                enabledFactors: new List<ReplaceMFARequest.EnabledFactorsEnum> { ReplaceMFARequest.EnabledFactorsEnum.Email },
+                isRecoveryCodesEnabled: false);
+
+            var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Mfa.MfaPutRequestBody>(src);
+
+            Assert.False(dst.IsRecoveryCodesEnabled);
+            Assert.Contains("\"is_recovery_codes_enabled\":false", SerializeAsSent(dst));
+        }
+
+        [Fact]
+        public void UpdateOrganizationUsersRequest_UnsetOperation_IsOmittedNotNull()
+        {
+            var src = new UpdateOrganizationUsersRequest(
+                users: new List<UpdateOrganizationUsersRequestUsersInner>
+                {
+                    new UpdateOrganizationUsersRequestUsersInner(
+                        id: "kp_057ee6debc624c70947b6ba512908c35",
+                        roles: new List<string> { "admin" }),
+                });
+
+            var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Organizations.Item.Users.UsersPatchRequestBody>(src);
+            var json = SerializeAsSent(dst);
+
+            _output.WriteLine("Wire body: " + json);
+
+            // The API answers 500 for "operation": null, so properties the caller never set
+            // must not appear at all.
+            Assert.DoesNotContain("\"operation\"", json);
+            Assert.DoesNotContain("\"permissions\"", json);
+            Assert.Contains("\"roles\":[\"admin\"]", json);
+        }
+
+        [Fact]
+        public void UpdateOrganizationUsersRequest_ExplicitOperation_SurvivesToTheWire()
+        {
+            var src = new UpdateOrganizationUsersRequest(
+                users: new List<UpdateOrganizationUsersRequestUsersInner>
+                {
+                    new UpdateOrganizationUsersRequestUsersInner(
+                        id: "kp_057ee6debc624c70947b6ba512908c35",
+                        operation: "delete"),
+                });
+
+            var dst = _mapper.Map<Kinde.Api.Kiota.Management.Api.V1.Organizations.Item.Users.UsersPatchRequestBody>(src);
+
+            Assert.Contains("\"operation\":\"delete\"", SerializeAsSent(dst));
         }
 
         [Fact]

--- a/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
+++ b/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
@@ -1379,8 +1379,13 @@ private static object FindReachableInstance(object root, Type target, int maxDep
         /// "Oauth2apple" vs "Oauth2Apple", or "EntraIdAzureAd" vs "Entra_id_azure_ad"), and
         /// DateTime -> DateTimeOffset conversion (which attaches the local offset, so the
         /// two aren't Equal() as an absolute instant comparison in every environment; wall
-        /// clock components are what matters here). A value reverted to the destination's
-        /// own default by the null-skip condition would not satisfy either fallback.
+        /// clock components are what matters here). The name-based fallback is gated on
+        /// both sides actually being enums -- otherwise a dropped int/bool/string sentinel
+        /// could false-positive against an unrelated destination value that happens to
+        /// stringify the same way (e.g. 42 vs "42", true vs "True"), which is exactly the
+        /// silent-drop failure this test exists to catch. A value reverted to the
+        /// destination's own default by the null-skip condition would not satisfy any of
+        /// these fallbacks.
         /// </summary>
         private static bool ValuesMatch(object? destValue, object sentinel)
         {
@@ -1396,7 +1401,11 @@ private static object FindReachableInstance(object root, Type target, int maxDep
             {
                 return destDate == sentinelDate;
             }
-            return string.Equals(destValue.ToString(), sentinel.ToString(), StringComparison.OrdinalIgnoreCase);
+            if (destValue.GetType().IsEnum && sentinel.GetType().IsEnum)
+            {
+                return string.Equals(destValue.ToString(), sentinel.ToString(), StringComparison.OrdinalIgnoreCase);
+            }
+            return false;
         }
 
         private static bool TryGetDateComponents(object value, out (int, int, int, int, int, int) components)
@@ -1504,19 +1513,13 @@ private static object FindReachableInstance(object root, Type target, int maxDep
                 return;
             }
 
-            object dest;
-            try
-            {
-                dest = _mapper.Map(source, sourceType, destType);
-            }
-            catch (Exception ex)
-            {
-                // A handful of source types (e.g. oneOf discriminators) can't map standalone
-                // with every scalar set to an unrelated sentinel; those are covered by their
-                // own dedicated tests elsewhere in this file.
-                _output.WriteLine($"Skipped {sourceType.Name} -> {destType.Name}: {ex.Message}");
-                return;
-            }
+            // No swallowing here: this sweep exists to catch a future regression in the
+            // null-skip condition, so a mapping failure on any pair must fail the test, not
+            // get logged and skipped. Source types that legitimately can't map standalone
+            // (oneOf/discriminator wrappers) don't throw -- they either have no scalar
+            // properties to smuggle through (see the early return above) or map cleanly to
+            // a null destination (see the check just below), so there's nothing to allowlist.
+            object dest = _mapper.Map(source, sourceType, destType);
 
             if (dest is null)
             {
@@ -1573,9 +1576,13 @@ private static object FindReachableInstance(object root, Type target, int maxDep
 
             if (typeof(Microsoft.Kiota.Abstractions.Serialization.IParsable).IsAssignableFrom(destType))
             {
-                var json = SerializeAsSentDynamic(dest, destType);
-                Assert.False(string.IsNullOrEmpty(json) && appliedSentinels.Count > 0,
-                    $"{destType.Name} serialized to an empty body despite explicit scalar values being set.");
+                // Not asserting on the JSON here -- the per-property comparison above is
+                // the real check for whether the null-skip condition dropped a value (a
+                // destination that dropped everything would still serialize to "{}", not an
+                // empty string, so an empty-body check wouldn't catch that anyway). This
+                // just exercises the backing-store serialization path so a pair that maps
+                // fine but can't actually be serialized still fails the test.
+                SerializeAsSentDynamic(dest, destType);
             }
         }
 

--- a/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
+++ b/Kinde.Api.Test/Integration/Mappers/AutoMapperTests.cs
@@ -1284,5 +1284,301 @@ private static object FindReachableInstance(object root, Type target, int maxDep
         }
 
         #endregion
+
+        #region Global null-skip condition -- full IBackedModel coverage
+
+        // KindeMapperConfiguration applies a single global AutoMapper.Internal condition
+        // that skips *every* null source value when mapping into an IBackedModel (Kiota)
+        // destination, across both profiles. The two hand-picked endpoint tests above
+        // (ReplaceMFARequest, UpdateOrganizationUsersRequest) prove the condition does what
+        // it's meant to for those specific properties, but they say nothing about the other
+        // ~100 CreateMap entries the same condition applies to. This walks every
+        // (source, destination) pair the condition actually reaches and proves an explicit,
+        // non-null scalar value on the source still lands on the destination -- i.e. the
+        // condition is filtering out unset/null values, not real ones.
+
+        /// <summary>
+        /// Every (source, destination) type pair, across both mapper profiles, where the
+        /// destination is an IBackedModel -- i.e. every pair the global null-skip condition
+        /// in KindeMapperConfiguration.BuildMapper applies to.
+        /// </summary>
+        public static IEnumerable<object[]> IBackedModelTypeMaps()
+        {
+            var mapper = KindeMapperConfiguration.Mapper;
+            var globalConfig = (AutoMapper.Internal.IGlobalConfiguration)mapper.ConfigurationProvider;
+            foreach (var typeMap in globalConfig.GetAllTypeMaps())
+            {
+                if (!typeof(Microsoft.Kiota.Abstractions.Store.IBackedModel).IsAssignableFrom(typeMap.DestinationType))
+                {
+                    continue;
+                }
+                if (typeMap.SourceType.IsInterface || typeMap.SourceType.IsAbstract)
+                {
+                    continue;
+                }
+
+                yield return new object[] { typeMap.SourceType, typeMap.DestinationType };
+            }
+        }
+
+        private static readonly HashSet<Type> ScalarPropertyTypes = new()
+        {
+            typeof(string),
+            typeof(bool), typeof(bool?),
+            typeof(int), typeof(int?),
+            typeof(long), typeof(long?),
+            typeof(double), typeof(double?),
+            typeof(DateTime), typeof(DateTime?),
+            typeof(DateTimeOffset), typeof(DateTimeOffset?),
+            typeof(Guid), typeof(Guid?),
+        };
+
+        private static bool TryGetSentinelValue(Type propertyType, out object sentinel)
+        {
+            var underlying = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+
+            if (underlying == typeof(string)) { sentinel = "kinde_null_skip_sentinel"; return true; }
+            if (underlying == typeof(bool)) { sentinel = true; return true; }
+            if (underlying == typeof(int)) { sentinel = 42; return true; }
+            if (underlying == typeof(long)) { sentinel = 42L; return true; }
+            if (underlying == typeof(double)) { sentinel = 4.2d; return true; }
+            if (underlying == typeof(DateTime)) { sentinel = new DateTime(2026, 1, 1); return true; }
+            if (underlying == typeof(DateTimeOffset)) { sentinel = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero); return true; }
+            if (underlying == typeof(Guid)) { sentinel = Guid.Parse("11111111-1111-1111-1111-111111111111"); return true; }
+            if (underlying.IsEnum)
+            {
+                var values = Enum.GetValues(underlying);
+                // A dropped property silently reverts to default(enum), which for
+                // zero-based enums is also values[0] -- picking that as the sentinel would
+                // make a real drop look like a pass. Prefer a non-default member.
+                var defaultValue = Activator.CreateInstance(underlying);
+                foreach (var candidate in values)
+                {
+                    if (!Equals(candidate, defaultValue))
+                    {
+                        sentinel = candidate!;
+                        return true;
+                    }
+                }
+                if (values.Length > 0)
+                {
+                    sentinel = values.GetValue(0)!;
+                    return true;
+                }
+            }
+
+            sentinel = null!;
+            return false;
+        }
+
+        /// <summary>
+        /// Compares a mapped destination value against the sentinel that was set on the
+        /// source, tolerating the legitimate transformations AutoMapper applies along the
+        /// way -- cross-type enum conversion (by name, case-insensitively, since some
+        /// destination enums use a different casing/format for the same member, e.g.
+        /// "Oauth2apple" vs "Oauth2Apple", or "EntraIdAzureAd" vs "Entra_id_azure_ad"), and
+        /// DateTime -> DateTimeOffset conversion (which attaches the local offset, so the
+        /// two aren't Equal() as an absolute instant comparison in every environment; wall
+        /// clock components are what matters here). A value reverted to the destination's
+        /// own default by the null-skip condition would not satisfy either fallback.
+        /// </summary>
+        private static bool ValuesMatch(object? destValue, object sentinel)
+        {
+            if (destValue is null)
+            {
+                return false;
+            }
+            if (destValue.Equals(sentinel))
+            {
+                return true;
+            }
+            if (TryGetDateComponents(destValue, out var destDate) && TryGetDateComponents(sentinel, out var sentinelDate))
+            {
+                return destDate == sentinelDate;
+            }
+            return string.Equals(destValue.ToString(), sentinel.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool TryGetDateComponents(object value, out (int, int, int, int, int, int) components)
+        {
+            switch (value)
+            {
+                case DateTime dt:
+                    components = (dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second);
+                    return true;
+                case DateTimeOffset dto:
+                    components = (dto.Year, dto.Month, dto.Day, dto.Hour, dto.Minute, dto.Second);
+                    return true;
+                default:
+                    components = default;
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Serializes a mapped destination the way the Kiota request adapter does, through
+        /// the backing store proxy, without requiring the model's compile-time type (the
+        /// per-type-pair tests only know Type instances, not generic type parameters).
+        /// </summary>
+        private static string SerializeAsSentDynamic(object model, Type modelType)
+        {
+            var factory = new Microsoft.Kiota.Abstractions.Store.BackingStoreSerializationWriterProxyFactory(
+                new Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory());
+            using var writer = factory.GetSerializationWriter("application/json");
+
+            var writeMethod = typeof(Microsoft.Kiota.Abstractions.Serialization.ISerializationWriter)
+                .GetMethods()
+                .First(m => m.Name == "WriteObjectValue"
+                    && m.IsGenericMethodDefinition
+                    && m.GetParameters().Length >= 2
+                    && m.GetParameters()[0].ParameterType == typeof(string)
+                    && m.GetParameters()[1].ParameterType.IsGenericParameter);
+            var invokeArgs = new object?[writeMethod.GetParameters().Length];
+            invokeArgs[0] = null;
+            invokeArgs[1] = model;
+            for (var i = 2; i < invokeArgs.Length; i++)
+            {
+                invokeArgs[i] = Array.CreateInstance(
+                    writeMethod.GetParameters()[i].ParameterType.GetElementType()!, 0);
+            }
+            writeMethod.MakeGenericMethod(modelType).Invoke(writer, invokeArgs);
+
+            using var stream = writer.GetSerializedContent();
+            using var reader = new System.IO.StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+
+        [Theory]
+        [MemberData(nameof(IBackedModelTypeMaps))]
+        public void IBackedModelDestinations_ExplicitScalarValues_SurviveMapping(Type sourceType, Type destType)
+        {
+            // Some members are deliberately excluded from a mapping via .ForMember(...,
+            // opt => opt.Ignore()) in the profile, unrelated to the null-skip condition --
+            // e.g. CreatePropertyRequest.Type/.Context are ignored because of a pre-existing
+            // enum incompatibility. Only assert on members the config actually maps, so this
+            // test verifies the null-skip condition specifically, not every ignore-mapping
+            // decision already made elsewhere.
+            var globalConfig = (AutoMapper.Internal.IGlobalConfiguration)_mapper.ConfigurationProvider;
+            var typeMap = globalConfig.FindTypeMapFor(sourceType, destType);
+            var activelyMappedSourceNames = typeMap is null
+                ? new HashSet<string>()
+                : typeMap.PropertyMaps
+                    .Where(pm => !pm.Ignored && pm.SourceMember is not null)
+                    .Select(pm => pm.SourceMember!.Name)
+                    .ToHashSet();
+
+            var settableScalarProps = sourceType
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(p => p.CanRead && p.CanWrite && p.GetIndexParameters().Length == 0)
+                .Where(p => ScalarPropertyTypes.Contains(p.PropertyType)
+                    || (Nullable.GetUnderlyingType(p.PropertyType) ?? p.PropertyType).IsEnum)
+                .ToList();
+
+            if (settableScalarProps.Count == 0)
+            {
+                return; // nothing scalar to smuggle through the mapping on this source type
+            }
+
+            var source = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(sourceType);
+            var appliedSentinels = new Dictionary<PropertyInfo, object>();
+
+            foreach (var prop in settableScalarProps)
+            {
+                if (!TryGetSentinelValue(prop.PropertyType, out var sentinel))
+                {
+                    continue;
+                }
+                try
+                {
+                    prop.SetValue(source, sentinel);
+                    appliedSentinels[prop] = sentinel;
+                }
+                catch
+                {
+                    // Some properties reject arbitrary values via custom setters; not this test's concern.
+                }
+            }
+
+            if (appliedSentinels.Count == 0)
+            {
+                return;
+            }
+
+            object dest;
+            try
+            {
+                dest = _mapper.Map(source, sourceType, destType);
+            }
+            catch (Exception ex)
+            {
+                // A handful of source types (e.g. oneOf discriminators) can't map standalone
+                // with every scalar set to an unrelated sentinel; those are covered by their
+                // own dedicated tests elsewhere in this file.
+                _output.WriteLine($"Skipped {sourceType.Name} -> {destType.Name}: {ex.Message}");
+                return;
+            }
+
+            if (dest is null)
+            {
+                // Wrapper/oneOf source types (e.g. *RequestOptions around a discriminated
+                // union) legitimately map to null when their real discriminator member
+                // (ActualInstance) isn't set -- setting unrelated scalar siblings doesn't
+                // change that. Not something the null-skip condition controls.
+                return;
+            }
+
+            var failures = new List<string>();
+            foreach (var (sourceProp, sentinel) in appliedSentinels)
+            {
+                if (!activelyMappedSourceNames.Contains(sourceProp.Name))
+                {
+                    continue; // ignored by the profile for reasons unrelated to the null-skip condition
+                }
+
+                var destProp = destType.GetProperty(sourceProp.Name, BindingFlags.Instance | BindingFlags.Public);
+                if (destProp is null || !destProp.CanRead)
+                {
+                    continue; // no same-named destination member -- not a property this condition could have dropped silently
+                }
+
+                var destValue = destProp.GetValue(dest);
+                var destUnderlying = Nullable.GetUnderlyingType(destProp.PropertyType) ?? destProp.PropertyType;
+                var sourceUnderlying = Nullable.GetUnderlyingType(sourceProp.PropertyType) ?? sourceProp.PropertyType;
+
+                var ok = ValuesMatch(destValue, sentinel);
+                if (!ok && destUnderlying.IsEnum && sourceUnderlying.IsEnum)
+                {
+                    // Some enum pairs go through a custom, semantically-equivalent but
+                    // textually different conversion that ValuesMatch's name comparison
+                    // can't see through (e.g. BridgeEnumByMember mapping "SHA256" ->
+                    // "RSASHA256" by [EnumMember] value, or "EntraIdAzureAd" ->
+                    // "Entra_id_azure_ad") -- the exact converted value is covered by
+                    // dedicated wire-format tests elsewhere in this file. Every Kiota
+                    // IBackedModel enum destination here is Nullable<TEnum>, so a value the
+                    // null-skip condition actually dropped would be null, not some specific
+                    // member -- unlike a non-nullable value type, it can't coincidentally
+                    // collide with default(enum) (which happens for some of these, e.g.
+                    // RSASHA256 is ordinal 0). So "non-null" is the correct, precise check
+                    // for whether this sweep's condition let the value through.
+                    ok = destValue is not null;
+                }
+                if (!ok)
+                {
+                    failures.Add($"{sourceType.Name}.{sourceProp.Name} (={sentinel}) -> {destType.Name}.{destProp.Name} (={destValue ?? "null"})");
+                }
+            }
+
+            Assert.True(failures.Count == 0,
+                $"Explicit value(s) dropped by the null-skip condition:\n{string.Join("\n", failures)}");
+
+            if (typeof(Microsoft.Kiota.Abstractions.Serialization.IParsable).IsAssignableFrom(destType))
+            {
+                var json = SerializeAsSentDynamic(dest, destType);
+                Assert.False(string.IsNullOrEmpty(json) && appliedSentinels.Count > 0,
+                    $"{destType.Name} serialized to an empty body despite explicit scalar values being set.");
+            }
+        }
+
+        #endregion
     }
 }

--- a/Kinde.Api/Mappers/KindeMapperConfiguration.cs
+++ b/Kinde.Api/Mappers/KindeMapperConfiguration.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Reflection;
 using AutoMapper;
+using AutoMapper.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Kiota.Abstractions.Store;
 
 namespace Kinde.Api.Mappers
 {
@@ -41,6 +43,17 @@ namespace Kinde.Api.Mappers
             {
                 cfg.AddProfile<ManagementApiMapperProfile>();
                 cfg.AddProfile<AccountsApiMapperProfile>();
+
+                // Kiota models keep their state in a backing store that distinguishes
+                // "never assigned" from "assigned null", and serializes the latter as an
+                // explicit JSON null. AutoMapper assigns every member, so an optional
+                // property the caller left unset would go on the wire as `"foo": null`
+                // rather than being omitted -- which the Kinde API rejects (e.g. PATCH
+                // /organizations/{org_code}/users answers 500 for `"operation": null`).
+                // Skip null sources so unset properties stay untouched, and therefore unsent.
+                cfg.Internal().ForAllPropertyMaps(
+                    pm => typeof(IBackedModel).IsAssignableFrom(pm.TypeMap.DestinationType),
+                    (pm, opt) => opt.Condition((src, dest, srcValue) => srcValue != null));
             };
 
             var configType = typeof(MapperConfiguration);

--- a/Kinde.Api/Mappers/KindeMapperConfiguration.cs
+++ b/Kinde.Api/Mappers/KindeMapperConfiguration.cs
@@ -44,16 +44,47 @@ namespace Kinde.Api.Mappers
                 cfg.AddProfile<ManagementApiMapperProfile>();
                 cfg.AddProfile<AccountsApiMapperProfile>();
 
-                // Kiota models keep their state in a backing store that distinguishes
-                // "never assigned" from "assigned null", and serializes the latter as an
-                // explicit JSON null. AutoMapper assigns every member, so an optional
-                // property the caller left unset would go on the wire as `"foo": null`
-                // rather than being omitted -- which the Kinde API rejects (e.g. PATCH
-                // /organizations/{org_code}/users answers 500 for `"operation": null`).
-                // Skip null sources so unset properties stay untouched, and therefore unsent.
-                cfg.Internal().ForAllPropertyMaps(
-                    pm => typeof(IBackedModel).IsAssignableFrom(pm.TypeMap.DestinationType),
-                    (pm, opt) => opt.Condition((src, dest, srcValue) => srcValue != null));
+                // This condition is global: it applies to every IBackedModel destination
+                // across both profiles (100+ CreateMap entries), not just the property that
+                // caused #85 -- and it can't be scoped narrower than that. The
+                // OpenAPI-generated source DTOs (Kinde.Api.Model.*) are plain POCOs with no
+                // "explicitly set to null" vs "never touched" distinction: both states are
+                // just `null` on the C# property. So "send an explicit null to clear a
+                // field" was never a capability this mapping could offer safely -- pre-fix,
+                // AutoMapper couldn't tell the two apart either, which is exactly why every
+                // untouched optional property was going out as a stray `"foo": null` and
+                // 500'ing the API (see #85). Explicit-null-clear via these DTOs is
+                // unsupported SDK-wide; there is no narrower condition that would restore it
+                // without reintroducing the original bug for every other optional property.
+                //
+                // cfg.Internal() reaches past AutoMapper's public config surface into
+                // AutoMapper.Internal, the same way the ctor lookup below reaches past the
+                // public constructor set via reflection. It's version-sensitive in the same
+                // way, but riskier: the ctor lookup fails loudly with a clear message if a
+                // future AutoMapper version removes the overload it expects, whereas this
+                // call is resolved at compile time against whatever AutoMapper version we
+                // built against, so a runtime version mismatch (e.g. a consumer's binding
+                // redirect resolving a different AutoMapper.Internal shape) could throw an
+                // opaque MissingMethodException, or -- worse -- silently stop applying the
+                // null-skip condition if the internal API's behavior changes without its
+                // signature changing. Wrap it so a version mismatch fails loudly instead of
+                // quietly reintroducing the null-forwarding bug this exists to fix.
+                try
+                {
+                    cfg.Internal().ForAllPropertyMaps(
+                        pm => typeof(IBackedModel).IsAssignableFrom(pm.TypeMap.DestinationType),
+                        (pm, opt) => opt.Condition((src, dest, srcValue) => srcValue != null));
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException(
+                        "Could not apply the null-source skip condition via AutoMapper.Internal's " +
+                        "ForAllPropertyMaps. This relies on AutoMapper's internal API surface, which " +
+                        "may have changed shape in the referenced AutoMapper version. Without this " +
+                        "condition, optional properties left unset by the caller are sent to the Kinde " +
+                        "API as explicit JSON nulls, which some endpoints reject (see #85).",
+                        ex);
+                }
             };
 
             var configType = typeof(MapperConfiguration);

--- a/Kinde.Api/Mappers/KindeMapperConfiguration.cs
+++ b/Kinde.Api/Mappers/KindeMapperConfiguration.cs
@@ -44,31 +44,19 @@ namespace Kinde.Api.Mappers
                 cfg.AddProfile<ManagementApiMapperProfile>();
                 cfg.AddProfile<AccountsApiMapperProfile>();
 
-                // This condition is global: it applies to every IBackedModel destination
-                // across both profiles (100+ CreateMap entries), not just the property that
-                // caused #85 -- and it can't be scoped narrower than that. The
-                // OpenAPI-generated source DTOs (Kinde.Api.Model.*) are plain POCOs with no
-                // "explicitly set to null" vs "never touched" distinction: both states are
-                // just `null` on the C# property. So "send an explicit null to clear a
-                // field" was never a capability this mapping could offer safely -- pre-fix,
-                // AutoMapper couldn't tell the two apart either, which is exactly why every
-                // untouched optional property was going out as a stray `"foo": null` and
-                // 500'ing the API (see #85). Explicit-null-clear via these DTOs is
-                // unsupported SDK-wide; there is no narrower condition that would restore it
-                // without reintroducing the original bug for every other optional property.
+                // Applies to every IBackedModel destination across both profiles. It can't
+                // be scoped narrower: the source DTOs are plain POCOs with no distinction
+                // between "explicitly null" and "never touched", so there was never a way to
+                // preserve explicit-null-clear for some properties without reintroducing
+                // stray `"foo": null` writes for the rest.
                 //
-                // cfg.Internal() reaches past AutoMapper's public config surface into
-                // AutoMapper.Internal, the same way the ctor lookup below reaches past the
-                // public constructor set via reflection. It's version-sensitive in the same
-                // way, but riskier: the ctor lookup fails loudly with a clear message if a
-                // future AutoMapper version removes the overload it expects, whereas this
-                // call is resolved at compile time against whatever AutoMapper version we
-                // built against, so a runtime version mismatch (e.g. a consumer's binding
-                // redirect resolving a different AutoMapper.Internal shape) could throw an
-                // opaque MissingMethodException, or -- worse -- silently stop applying the
-                // null-skip condition if the internal API's behavior changes without its
-                // signature changing. Wrap it so a version mismatch fails loudly instead of
-                // quietly reintroducing the null-forwarding bug this exists to fix.
+                // cfg.Internal() reaches past AutoMapper's public config surface, the same
+                // way the ctor lookup below reaches past the public constructor set via
+                // reflection -- but riskier, since it's resolved at compile time against
+                // whatever AutoMapper version we built against. A runtime version mismatch
+                // could throw an opaque MissingMethodException, or silently stop applying
+                // the condition if the internal API's behavior changes without its signature
+                // changing. Wrap it so a version mismatch fails loudly instead.
                 try
                 {
                     cfg.Internal().ForAllPropertyMaps(
@@ -82,7 +70,7 @@ namespace Kinde.Api.Mappers
                         "ForAllPropertyMaps. This relies on AutoMapper's internal API surface, which " +
                         "may have changed shape in the referenced AutoMapper version. Without this " +
                         "condition, optional properties left unset by the caller are sent to the Kinde " +
-                        "API as explicit JSON nulls, which some endpoints reject (see #85).",
+                        "API as explicit JSON nulls, which some endpoints reject.",
                         ex);
                 }
             };


### PR DESCRIPTION
## Summary

Add tests and mapping behavior to preserve Kiota backing-store semantics:
- Add a `SerializeAsSent` helper that serializes models via `BackingStoreSerializationWriterProxyFactory`.
- Add tests verifying that unset vs. explicit `null` properties are serialized correctly (e.g. `is_recovery_codes_enabled` and organization user operation/permissions).
- Update `KindeMapperConfiguration` to skip `null` source values for destinations implementing `IBackedModel` by applying `Condition(srcValue != null)` on property maps. This prevents AutoMapper from overwriting "never assigned" backing-store defaults with explicit `null` values that the API rejects.

## Explain your changes

Fixes #85

## Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the contributing guidelines.
- [x] I agree to the terms within the code of conduct.
